### PR TITLE
docs: update Arch Linux instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Via cargo:
 cargo install tracexec --bin tracexec
 ```
 
-You can also install `tracexec` from AUR.
+Arch Linux users can also install from the official repositories via `pacman -S tracexec`.
 
 ### Binary
 


### PR DESCRIPTION
Now in official repositories: <https://archlinux.org/packages/extra/x86_64/tracexec/> 🥳
