### PR TITLE
refactor: use libseccomp crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,8 +169,11 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y build-essential autopoint gettext libelf-dev zlib1g-dev \
-            libelf-dev:${{ matrix.os-arch }} zlib1g-dev:${{ matrix.os-arch }} \
-            libseccomp2:${{ matrix.os-arch }} libseccomp-dev:${{ matrix.os-arch }}
+            libelf-dev:${{ matrix.os-arch }} zlib1g-dev:${{ matrix.os-arch }}
+          sudo apt-get install -y libseccomp-dev:${{ matrix.os-arch }}
+          if ! [ "${{ matrix.static_libseccomp }}" = "true" ]; then
+            sudo apt-get install -y libseccomp2:${{ matrix.os-arch }}
+          fi
       # - name: Prepare libelf and zlib
       #   run: 3rdparty/prepare-native-dependencies.sh ${{ matrix.arch }}
       - name: Cache Cargo dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
             no-default-features: false
             args: '-F static,vendored'
             rust_flags: -C target-feature=+crt-static
+            static_libseccomp: true
           - os: ubuntu-24.04
             os-arch: arm64
             target: aarch64-unknown-linux-gnu
@@ -116,6 +117,7 @@ jobs:
             no-default-features: false
             args: '-F static,vendored'
             rust_flags: -C target-feature=+crt-static
+            static_libseccomp: true
           - os: ubuntu-24.04
             os-arch: riscv64
             target: riscv64gc-unknown-linux-gnu
@@ -131,9 +133,12 @@ jobs:
             args: '-F ebpf,static,vendored'
             no-default-features: true
             rust_flags: -C target-feature=+crt-static
+            static_libseccomp: true
     runs-on: ${{ matrix.os }}
     env:
       RUSTFLAGS: ${{ matrix.rust_flags }}
+      LIBSECCOMP_LINK_TYPE: ${{ matrix.static_libseccomp && 'static' || 'dylib' }}
+      LIBSECCOMP_LIB_PATH: ${{ matrix.static_libseccomp && format('/{0}', matrix.libpath) || '/this/path/does/not/exist' }}
     #   LIBBPF_SYS_LIBRARY_PATH: ${{ github.workspace }}/3rdparty/${{ matrix.arch }}/${{ matrix.libpath }}
     #   LIBBPF_SYS_EXTRA_CFLAGS: -I ${{ github.workspace }}/3rdparty/${{ matrix.arch }}/usr/include
     steps:
@@ -164,25 +169,16 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y build-essential autopoint gettext libelf-dev zlib1g-dev \
-            libelf-dev:${{ matrix.os-arch }} zlib1g-dev:${{ matrix.os-arch }}
+            libelf-dev:${{ matrix.os-arch }} zlib1g-dev:${{ matrix.os-arch }} \
+            libseccomp2:${{ matrix.os-arch }} libseccomp-dev:${{ matrix.os-arch }}
       # - name: Prepare libelf and zlib
       #   run: 3rdparty/prepare-native-dependencies.sh ${{ matrix.arch }}
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@v2
       - name: Run cargo build with default features
-        if: matrix.target != 'riscv64gc-unknown-linux-gnu'
         run: cargo build --bins --tests --target ${{ matrix.target }} ${{ matrix.args }}
-      - name: Run cargo build with no default features
-        if: matrix.target == 'riscv64gc-unknown-linux-gnu'
-        run: cargo build --bins --tests --target ${{ matrix.target }} --no-default-features ${{ matrix.args }}
       - name: Run cargo check with default features
-        if: matrix.target != 'riscv64gc-unknown-linux-gnu'
         run: cargo check --target ${{ matrix.target }} ${{ matrix.args }}
-        env:
-          RUST_BACKTRACE: full
-      - name: Run cargo check with no default features
-        if: matrix.target == 'riscv64gc-unknown-linux-gnu'
-        run: cargo check --target ${{ matrix.target }} --no-default-features ${{ matrix.args }}
         env:
           RUST_BACKTRACE: full
       - name: Run cargo test with default features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,11 @@ jobs:
         run: |
           sudo apt update -y
           sudo apt install -y {binutils,gcc}-{aarch64,riscv64}-linux-gnu \
-            build-essential autopoint gettext libelf-dev zlib1g-dev \
-            libelf-dev:${{ matrix.os-arch }} zlib1g-dev:${{ matrix.os-arch }} \
-            libseccomp2:${{ matrix.os-arch }} libseccomp-dev:${{ matrix.os-arch }}
+            build-essential autopoint gettext libelf-dev zlib1g-dev
+          sudo apt-get install -y libseccomp-dev:${{ matrix.os-arch }}
+          if ! [ "${{ matrix.static_libseccomp }}" = "true" ]; then
+            sudo apt-get install -y libseccomp2:${{ matrix.os-arch }}
+          fi
       # - name: Prepare libelf and zlib
       #   run: 3rdparty/prepare-native-dependencies.sh ${{ matrix.arch }}
       - name: Publish to crates.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
             features: static,vendored
             artifact-suffix: -static
             rust_flags: -C target-feature=+crt-static
+            static_libseccomp: true
           - os: ubuntu-24.04
             os-arch: arm64
             target: aarch64-unknown-linux-gnu
@@ -55,6 +56,7 @@ jobs:
             features: static,vendored
             artifact-suffix: -static
             rust_flags: -C target-feature=+crt-static
+            static_libseccomp: true
           - os: ubuntu-24.04
             os-arch: riscv64
             target: riscv64gc-unknown-linux-gnu
@@ -71,6 +73,7 @@ jobs:
             features: ebpf,static,vendored
             artifact-suffix: -static
             rust_flags: -C target-feature=+crt-static
+            static_libseccomp: true
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -104,7 +107,8 @@ jobs:
           sudo apt update -y
           sudo apt install -y {binutils,gcc}-{aarch64,riscv64}-linux-gnu \
             build-essential autopoint gettext libelf-dev zlib1g-dev \
-            libelf-dev:${{ matrix.os-arch }} zlib1g-dev:${{ matrix.os-arch }}
+            libelf-dev:${{ matrix.os-arch }} zlib1g-dev:${{ matrix.os-arch }} \
+            libseccomp2:${{ matrix.os-arch }} libseccomp-dev:${{ matrix.os-arch }}
       # - name: Prepare libelf and zlib
       #   run: 3rdparty/prepare-native-dependencies.sh ${{ matrix.arch }}
       - name: Publish to crates.io
@@ -120,6 +124,8 @@ jobs:
       - uses: taiki-e/upload-rust-binary-action@v1
         env:
           RUSTFLAGS: ${{ matrix.rust_flags }}
+          LIBSECCOMP_LINK_TYPE: ${{ matrix.static_libseccomp && 'static' || 'dylib' }}
+          LIBSECCOMP_LIB_PATH: ${{ matrix.static_libseccomp && format('/{0}', matrix.libpath) || '/this/path/does/not/exist' }}
         #   LIBBPF_SYS_LIBRARY_PATH: ${{ github.workspace }}/3rdparty/${{ matrix.arch }}/${{ matrix.libpath }}
         #   LIBBPF_SYS_EXTRA_CFLAGS: -I ${{ github.workspace }}/3rdparty/${{ matrix.arch }}/usr/include
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,6 +176,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
@@ -403,7 +409,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "crossterm_winapi",
  "futures-core",
  "mio",
@@ -973,7 +979,7 @@ version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73d2e61404e42ba2d97a9acbc24d046cfae978393e21b428e780adbc997504d0"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "libbpf-sys",
  "libc",
  "vsprintf",
@@ -1012,9 +1018,27 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "libc",
 ]
+
+[[package]]
+name = "libseccomp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21c57fd8981a80019807b7b68118618d29a87177c63d704fc96e6ecd003ae5b3"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "libseccomp-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libseccomp-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7cbbd4ad467251987c6e5b47d53b11a5a05add08f2447a9e2d70aef1e0d138"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1111,7 +1135,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -1123,7 +1147,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -1186,7 +1210,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "block2",
  "libc",
  "objc2",
@@ -1202,7 +1226,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -1232,7 +1256,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "block2",
  "libc",
  "objc2",
@@ -1244,7 +1268,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -1256,7 +1280,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "block2",
  "objc2",
  "objc2-foundation",
@@ -1435,7 +1459,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -1465,7 +1489,7 @@ version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -1592,7 +1616,7 @@ version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1637,15 +1661,6 @@ name = "sdd"
 version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60a7b59a5d9b0099720b417b6325d91a52cbf5b3dcb5041d864be53eefa58abc"
-
-[[package]]
-name = "seccompiler"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345a3e4dddf721a478089d4697b83c6c0a8f5bf16086f6c13397e4534eb6e2e5"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -1997,7 +2012,7 @@ dependencies = [
  "assert_cmd",
  "atoi",
  "better-panic",
- "bitflags",
+ "bitflags 2.6.0",
  "bytes",
  "cfg-if",
  "clap",
@@ -2017,13 +2032,13 @@ dependencies = [
  "libbpf-cargo",
  "libbpf-rs",
  "libbpf-sys",
+ "libseccomp",
  "nix 0.29.0",
  "paste",
  "predicates",
  "ratatui",
  "regex-cursor",
  "rstest",
- "seccompiler",
  "serde",
  "serde_json",
  "serial_test",
@@ -2328,7 +2343,7 @@ version = "0.31.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3f45d1222915ef1fd2057220c1d9d9624b7654443ea35c3877f7a52bd0a5a2d"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "rustix",
  "wayland-backend",
  "wayland-scanner",
@@ -2340,7 +2355,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -2352,7 +2367,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,6 @@ owo-colors = { version = "4.0.0", package = "kxxt-owo-colors", features = [
     "global-colorized-control",
 ] }
 shell-quote = { version = "0.7.1" }
-seccompiler = { version = "0.4.0", optional = true }
 atoi = "2.0.0"
 tracing = { version = "0.1.40", features = ["release_max_level_info"] }
 tracing-error = "0.2.0"
@@ -79,6 +78,7 @@ serde_json = "1.0.120"
 libbpf-rs = { version = "0.24.6", optional = true, default-features = false }
 # libbpf-sys exists here because we want to control its features
 libbpf-sys = { version = "1", optional = true, default-features = false }
+libseccomp = { version = "0.3.0", optional = true }
 # tui-prompts = { version = "0.3.11", path = "../../contrib/tui-prompts" }
 # tui-popup = { version = "0.3.0", path = "../../contrib/tui-popup" }
 
@@ -95,7 +95,7 @@ libbpf-cargo = { version = "0.24.6", default-features = false }
 [features]
 default = ["recommended", "vendored-libbpf"]
 recommended = ["seccomp-bpf", "ebpf"]
-seccomp-bpf = ["dep:seccompiler"]
+seccomp-bpf = ["dep:libseccomp"]
 ebpf = ["dep:libbpf-rs", "dep:libbpf-sys"]
 # The ebpf-debug feature is not meant for end users.
 # This feature also has a bug:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -11,7 +11,7 @@ The eBPF feature should work on 6.x kernels.
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/tracexec.svg)](https://repology.org/project/tracexec/versions)
 
-Arch Linux users can also install from the official repositories via `pacman -S tracexec`.
+Arch Linux users can install from the official repositories via `pacman -S tracexec`.
 
 ## Install From Source
 
@@ -21,10 +21,19 @@ To install from source, the following dependencies are needed:
 - `libbpf`: if not using `vendored-libbpf`
 - `zlib`: if not using `vendored-zlib`
 - `libelf`: if not using `vendored-libelf`
+- `libseccomp`: For `seccomp-bpf` feature.
 - If any library vendoring feature is enabled:
   - `build-essential` `autopoint` `gettext` for Debian based distros
   - `base-devel` for Arch Linux
 - `clang` for compiling eBPF program.
+
+### Library Linkage
+
+By default, we dynamically link to libseccomp. In order to statically link to libseccomp,
+please set `LIBSECCOMP_LINK_TYPE` to `static` and set `LIBSECCOMP_LIB_PATH` to the path of
+the directory containing `libseccomp.a`.
+
+To control whether to dynamically link to libbpf, libelf and zlib, consult the next `Feature Flags` section.
 
 ### Feature Flags
 

--- a/src/seccomp.rs
+++ b/src/seccomp.rs
@@ -1,21 +1,8 @@
-use seccompiler::{SeccompAction, SeccompFilter, TargetArch};
+use libseccomp::{ScmpAction, ScmpFilterContext};
 
-pub fn create_seccomp_filter() -> SeccompFilter {
-  SeccompFilter::new(
-    vec![
-      (nix::libc::SYS_execve, vec![]),
-      (nix::libc::SYS_execveat, vec![]),
-    ]
-    .into_iter()
-    .collect(),
-    SeccompAction::Allow,
-    SeccompAction::Trace(0),
-    #[cfg(target_arch = "x86_64")]
-    TargetArch::x86_64,
-    #[cfg(target_arch = "aarch64")]
-    TargetArch::aarch64,
-    #[cfg(target_arch = "riscv64")]
-    TargetArch::riscv64,
-  )
-  .expect("failed to create seccomp filter!")
+pub fn create_seccomp_filters() -> color_eyre::Result<ScmpFilterContext> {
+  let mut filter = ScmpFilterContext::new_filter(ScmpAction::Allow)?;
+  filter.add_rule(ScmpAction::Trace(0), nix::libc::SYS_execve as i32)?;
+  filter.add_rule(ScmpAction::Trace(0), nix::libc::SYS_execveat as i32)?;
+  Ok(filter)
 }

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -255,9 +255,8 @@ impl Tracer {
       move |program_path| {
         #[cfg(feature = "seccomp-bpf")]
         if seccomp_bpf == SeccompBpf::On {
-          let filter = seccomp::create_seccomp_filter();
-          let bpf: seccompiler::BpfProgram = filter.try_into()?;
-          seccompiler::apply_filter(&bpf)?;
+          let filter = seccomp::create_seccomp_filters()?;
+          filter.load()?;
         }
 
         if !with_tty {


### PR DESCRIPTION
libseccomp supports x86_32 and a lot more archs.
It will make supporting 32bit exec tracing in
ptrace backend easier.