### PR TITLE
build: add nix flake for testing eBPF across different kernel versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ ebpf = ["dep:libbpf-rs", "dep:libbpf-sys"]
 # Either cargo doesn't rebuild and run build.rs on feature flag change,
 # or some logic is wrong in build.rs
 ebpf-debug = ["ebpf"]
+ebpf-no-rcu-kfuncs = ["ebpf"] # Avoid using rcu helpers. Necessary for kernel version < 6.2
 static = ["libbpf-sys/static"]
 vendored = ["libbpf-sys/vendored", "vendored-libbpf"]
 vendored-libbpf = ["libbpf-sys/vendored-libbpf", "libbpf-cargo/default"]

--- a/build.rs
+++ b/build.rs
@@ -12,6 +12,7 @@ fn main() {
     const BPF_SRC: &str = "src/bpf/tracexec_system.bpf.c";
     let manifest_dir =
       PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"));
+    let bpf_src = manifest_dir.join(BPF_SRC);
     let skel_out = manifest_dir
       .clone()
       .join("src")
@@ -40,7 +41,7 @@ fn main() {
       clang_args.push(OsStr::new("-DEBPF_DEBUG"));
     }
     SkeletonBuilder::new()
-      .source(BPF_SRC)
+      .source(bpf_src)
       .clang_args(clang_args)
       .build_and_generate(&skel_out)
       .unwrap();

--- a/build.rs
+++ b/build.rs
@@ -40,6 +40,9 @@ fn main() {
     if cfg!(any(feature = "ebpf-debug", debug_assertions)) {
       clang_args.push(OsStr::new("-DEBPF_DEBUG"));
     }
+    if cfg!(feature = "ebpf-no-rcu-kfuncs") {
+      clang_args.push(OsStr::new("-DNO_RCU_KFUNCS"));
+    }
     SkeletonBuilder::new()
       .source(bpf_src)
       .clang_args(clang_args)

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,74 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1729741221,
+        "narHash": "sha256-8AHZZXs1lFkERfBY0C8cZGElSo33D/et7NKEpLRmvzo=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "f235b656ee5b2bfd6d94c3bfd67896a575d4a6ed",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1729850857,
+        "narHash": "sha256-WvLXzNNnnw+qpFOmgaM3JUlNEH+T4s22b5i2oyyCpXE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "41dea55321e5a999b17033296ac05fe8a8b5a257",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1727825735,
+        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,15 +5,17 @@
     crane.url = "github:ipetkov/crane";
   };
 
-  outputs = inputs@{ flake-parts, crane, ... }:
+  outputs = inputs@{ flake-parts, crane, nixpkgs, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } (
       { withSystem, flake-parts-lib, ... }:
       let inherit (flake-parts-lib) importApply;
         tracexec.default = importApply ./nix/tracexec.nix { inherit crane; };
+        ukci.default = importApply ./nix/ukci.nix { inherit nixpkgs; };
       in
       {
         imports = [
           tracexec.default
+          ukci.default
         ];
         flake = {
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,62 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    crane.url = "github:ipetkov/crane";
+  };
+
+  outputs = inputs@{ flake-parts, crane, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      flake = {
+
+      };
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "riscv64-linux"
+      ];
+      perSystem = { config, lib, pkgs, ... }:
+        let
+          cargoToml = lib.importTOML ./Cargo.toml;
+          craneLib = crane.mkLib pkgs;
+        in
+        {
+          packages.default =
+            let
+              cFilter = path: _type: builtins.match ".*\.[ch]$" path != null;
+              symlinkFilter = _path: type: type == "symlink";
+              sourceFilter = path: type:
+                (cFilter path type) || (symlinkFilter path type) || (craneLib.filterCargoSources path type);
+            in
+            craneLib.buildPackage {
+              src = lib.cleanSourceWith {
+                src =  ./.;
+                filter = sourceFilter;
+                name = "source";
+              };
+              buildInputs = with pkgs; [
+                elfutils
+                zlib
+                libseccomp
+              ];
+              nativeBuildInputs = with pkgs; [
+                pkg-config
+                clang # For building eBPF
+              ];
+              hardeningDisable = [
+                "zerocallusedregs"
+              ];
+              # Don't store logs
+              TRACEXEC_DATA = "/tmp";
+            };
+
+          devShells.default = pkgs.mkShell {
+            name = "Development Shell";
+            packages = with pkgs; [
+              strace
+            ];
+            shellHook = ''export TRACEXEC_LOGLEVEL=debug'';
+          };
+        };
+  };
+}

--- a/nix/initramfs.nix
+++ b/nix/initramfs.nix
@@ -1,0 +1,139 @@
+# Credits: https://github.com/jordanisaacs/kernel-module-flake
+# Original Copyright Notice:
+
+# MIT License
+
+# Copyright (c) 2022 Jordan Isaacs
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+{ lib
+, buildEnv
+, writeScript
+, makeInitrdNG
+, bash
+, busybox
+, kmod
+, dropbear
+,
+}: { kernel
+   , modules ? [ ]
+   , extraBin ? { }
+   , extraContent ? { }
+   , storePaths ? [ ]
+   , extraInit ? ""
+   ,
+   }:
+let
+  busyboxStatic = busybox.override { enableStatic = true; };
+
+  initrdBinEnv = buildEnv {
+    name = "initrd-emergency-env";
+    paths = map lib.getBin initrdBin;
+    pathsToLink = [ "/bin" "/sbin" ];
+    postBuild = lib.concatStringsSep "\n" (lib.mapAttrsToList (n: v: "ln -s ${v} $out/bin/${n}") extraBin);
+  };
+
+  moduleEnv = buildEnv {
+    name = "initrd-modules";
+    paths = modules;
+    pathsToLink = [ "/lib/modules/${kernel.modDirVersion}/misc" ];
+  };
+
+  content =
+    {
+      "/bin" = "${initrdBinEnv}/bin";
+      "/sbin" = "${initrdBinEnv}/sbin";
+      "/init" = init;
+      "/modules" = "${moduleEnv}/lib/modules/${kernel.modDirVersion}/misc";
+    }
+    // extraContent;
+
+  initrdBin = [ bash busyboxStatic kmod dropbear ];
+
+  initialRamdisk = makeInitrdNG {
+    compressor = "gzip";
+    strip = false;
+    contents =
+      map
+        (path: {
+          source = path;
+        })
+        storePaths
+      ++ lib.mapAttrsToList
+        (n: v: {
+          source = v;
+          target = n;
+        })
+        content;
+  };
+
+  init = writeScript "init" ''
+    #!/bin/sh
+
+    export PATH=/bin/
+
+    mkdir -p /proc
+    mkdir -p /sys
+    mkdir -p /dev
+    mount -t devtmpfs none /dev
+    mkdir -p /dev/pts
+    mount -t devpts none /dev/pts
+    mount -t proc none /proc
+    mount -t sysfs none /sys
+    mount -t debugfs debugfs /sys/kernel/debug
+
+    mkdir -p /etc/dropbear
+    echo /bin/bash > /etc/shells
+    cat > /etc/passwd << "EOF"
+    root::0:0:root:/root:/bin/bash
+    EOF
+    passwd -d root
+
+    ifconfig lo 127.0.0.1
+    ifconfig eth0 10.0.2.15
+    ip route add default via 10.0.2.2
+
+    mkdir -p /run/booted-system/kernel-modules/lib/modules/${kernel.modDirVersion}/build
+    tar -xf /sys/kernel/kheaders.tar.xz -C /run/booted-system/kernel-modules/lib/modules/${kernel.modDirVersion}/build
+
+    dropbear -F -R -E -B &
+
+    ${extraInit}
+
+    cat <<!
+
+    Boot took $(cut -d' ' -f1 /proc/uptime) seconds
+
+            _       _     __ _
+      /\/\ (_)_ __ (_)   / /(_)_ __  _   ___  __
+     /    \| | '_ \| |  / / | | '_ \| | | \ \/ /
+    / /\/\ \ | | | | | / /__| | | | | |_| |>  <
+    \/    \/_|_| |_|_| \____/_|_| |_|\__,_/_/\_\
+
+    Welcome to mini_linux
+
+
+    !
+
+    # Get a new session to allow for job control and ctrl-* support
+    exec setsid -c /bin/sh
+  '';
+in
+initialRamdisk

--- a/nix/kernel-build.nix
+++ b/nix/kernel-build.nix
@@ -1,0 +1,121 @@
+# Credits: https://github.com/jordanisaacs/kernel-module-flake
+# Original Copyright Notice:
+
+# MIT License
+
+# Copyright (c) 2022 Jordan Isaacs
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+{ stdenv
+, lib
+, callPackage
+, buildPackages
+, rustPlatform
+,
+}: { src
+   , configfile
+   , modDirVersion
+   , version
+   , enableGdb ? false
+   , # Install the GDB scripts
+     kernelPatches ? [ ]
+   , nixpkgs
+   , # Nixpkgs source
+   }:
+let
+  kernel =
+    ((callPackage "${nixpkgs}/pkgs/os-specific/linux/kernel/manual-config.nix" { })
+      {
+        inherit src modDirVersion version kernelPatches configfile;
+        inherit lib stdenv;
+
+        # Because allowedImportFromDerivation is not enabled,
+        # the function cannot set anything based on the configfile. These settings do not
+        # actually change the .config but let the kernel derivation know what can be built.
+        # See manual-config.nix for other options
+        config = {
+          # Enables the dev build
+          CONFIG_MODULES = "y";
+        };
+      }).overrideAttrs (old: {
+      nativeBuildInputs =
+        old.nativeBuildInputs;
+
+      dontStrip = true;
+
+      postInstall = ''
+        mkdir -p $dev
+        cp vmlinux $dev/
+        if [ -z "''${dontStrip-}" ]; then
+          installFlagsArray+=("INSTALL_MOD_STRIP=1")
+        fi
+        make modules_install $makeFlags "''${makeFlagsArray[@]}" \
+          $installFlags "''${installFlagsArray[@]}"
+        if [ -L "$out/lib/modules/${modDirVersion}/build" ]; then
+          unlink $out/lib/modules/${modDirVersion}/build
+        fi
+        if [ -L "$out/lib/modules/${modDirVersion}/source" ]; then
+          unlink $out/lib/modules/${modDirVersion}/source
+        fi
+
+        mkdir -p $dev/lib/modules/${modDirVersion}/{build,source}
+
+        # To save space, exclude a bunch of unneeded stuff when copying.
+        (cd .. && rsync --archive --prune-empty-dirs \
+            --exclude='/build/' \
+            * $dev/lib/modules/${modDirVersion}/source/)
+
+        cd $dev/lib/modules/${modDirVersion}/source
+
+        cp $buildRoot/{.config,Module.symvers} $dev/lib/modules/${modDirVersion}/build
+
+        make modules_prepare $makeFlags "''${makeFlagsArray[@]}" O=$dev/lib/modules/${modDirVersion}/build
+
+        ${lib.optionalString enableGdb ''
+          echo "Make scripts"
+          make scripts_gdb $makeFlags "''${makeFlagsArray[@]}" O=$dev/lib/modules/${modDirVersion}/build
+        ''}
+
+        # For reproducibility, removes accidental leftovers from a `cc1` call
+        # from a `try-run` call from the Makefile
+        rm -f $dev/lib/modules/${modDirVersion}/build/.[0-9]*.d
+
+        # Keep some extra files on some arches (powerpc, aarch64)
+        for f in arch/powerpc/lib/crtsavres.o arch/arm64/kernel/ftrace-mod.o; do
+          if [ -f "$buildRoot/$f" ]; then
+            cp $buildRoot/$f $dev/lib/modules/${modDirVersion}/build/$f
+          fi
+        done
+
+        # Not doing the nix default of removing files from the source tree.
+        # This is because the source tree is necessary for debugging with GDB.
+
+        # Remove reference to kmod
+        sed -i Makefile -e 's|= ${buildPackages.kmod}/bin/depmod|= depmod|'
+      '';
+    });
+
+  kernelPassthru = {
+    inherit (configfile) structuredConfig;
+    inherit modDirVersion configfile;
+    passthru = kernel.passthru // (removeAttrs kernelPassthru [ "passthru" ]);
+  };
+in
+lib.extendDerivation true kernelPassthru kernel

--- a/nix/kernel-configure.nix
+++ b/nix/kernel-configure.nix
@@ -1,0 +1,143 @@
+# Credits: https://github.com/jordanisaacs/kernel-module-flake
+# Original Copyright Notice:
+
+# MIT License
+
+# Copyright (c) 2022 Jordan Isaacs
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+{ stdenv
+, lib
+, perl
+, gmp
+, libmpc
+, mpfr
+, bison
+, flex
+, pahole
+, buildPackages
+, rustPlatform
+, rustc
+, rustfmt
+, cargo
+, rust-bindgen
+,
+}: { nixpkgs
+   , kernel
+   , # generate-config.pl flags. see below
+     generateConfigFlags
+   , structuredExtraConfig
+   , enableRust ? false
+   ,
+   }:
+let
+  nativeBuildInputs =
+    [ perl gmp libmpc mpfr bison flex ]
+    ++ lib.optionals enableRust [ rustfmt rustc cargo rust-bindgen ];
+
+  passthru = rec {
+    module = import "${nixpkgs}/nixos/modules/system/boot/kernel_config.nix";
+    # used also in apache
+    # { modules = [ { options = res.options; config = svc.config or svc; } ];
+    #   check = false;
+    # The result is a set of two attributes
+    moduleStructuredConfig =
+      (lib.evalModules {
+        modules = [
+          module
+          {
+            settings = structuredExtraConfig;
+            _file = "structuredExtraConfig";
+          }
+        ];
+      }).config;
+
+    structuredConfig = moduleStructuredConfig.settings;
+  };
+in
+stdenv.mkDerivation (
+  {
+    kernelArch = stdenv.hostPlatform.linuxArch;
+    extraMakeFlags = [ ];
+
+    inherit (kernel) src patches version;
+    pname = "linux-config";
+
+    # Flags that get passed to generate-config.pl
+    # ignoreConfigErrors: Ignores any config errors in script (eg unused options)
+    # autoModules: Build every available module
+    # preferBuiltin: Build modules as builtin
+    inherit (generateConfigFlags) autoModules preferBuiltin ignoreConfigErrors;
+    generateConfig = "${nixpkgs}/pkgs/os-specific/linux/kernel/generate-config.pl";
+
+    kernelConfig = passthru.moduleStructuredConfig.intermediateNixConfig;
+    passAsFile = [ "kernelConfig" ];
+
+    depsBuildBuild = [ buildPackages.stdenv.cc ];
+    inherit nativeBuildInputs;
+
+    platformName = stdenv.hostPlatform.linux-kernel.name;
+    # e.g. "bzImage"
+    kernelTarget = stdenv.hostPlatform.linux-kernel.target;
+
+    makeFlags =
+      lib.optionals (stdenv.hostPlatform.linux-kernel ? makeFlags) stdenv.hostPlatform.linux-kernel.makeFlags;
+
+    postPatch =
+      kernel.postPatch
+      + ''
+        # Patch kconfig to print "###" after every question so that
+        # generate-config.pl from the generic builder can answer them.
+        sed -e '/fflush(stdout);/i\printf("###");' -i scripts/kconfig/conf.c
+      '';
+
+    preUnpack = kernel.preUnpack or "";
+
+    buildPhase = ''
+      export buildRoot="''${buildRoot:-build}"
+      export HOSTCC=$CC_FOR_BUILD
+      export HOSTCXX=$CXX_FOR_BUILD
+      export HOSTAR=$AR_FOR_BUILD
+      export HOSTLD=$LD_FOR_BUILD
+      # Get a basic config file for later refinement with $generateConfig.
+      make $makeFlags \
+        -C . O="$buildRoot" allnoconfig \
+        HOSTCC=$HOSTCC HOSTCXX=$HOSTCXX HOSTAR=$HOSTAR HOSTLD=$HOSTLD \
+        CC=$CC OBJCOPY=$OBJCOPY OBJDUMP=$OBJDUMP READELF=$READELF \
+        $makeFlags
+
+      # Create the config file.
+      echo "generating kernel configuration..."
+      ln -s "$kernelConfigPath" "$buildRoot/kernel-config"
+      DEBUG=1 ARCH=$kernelArch KERNEL_CONFIG="$buildRoot/kernel-config" AUTO_MODULES=$autoModules \
+        PREFER_BUILTIN=$preferBuiltin BUILD_ROOT="$buildRoot" SRC=. MAKE_FLAGS="$makeFlags" \
+        perl -w $generateConfig
+    '';
+
+    installPhase = "mv $buildRoot/.config $out";
+
+    enableParallelBuilding = true;
+
+    inherit passthru;
+  }
+    // lib.optionalAttrs enableRust {
+    RUST_LIB_SRC = rustPlatform.rustLibSrc;
+  }
+)

--- a/nix/kernel-source.nix
+++ b/nix/kernel-source.nix
@@ -26,10 +26,10 @@
 { pkgs
 , lib ? pkgs.lib
 , enableGdb
-,
+, version
+, sha256
 }:
 let
-  version = "6.6.58";
   localVersion = "-ukci";
 in
 {
@@ -40,7 +40,7 @@ in
     src =
       pkgs.fetchurl {
         url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
-        sha256 = "sha256-59+B5YjXD6tew+w7sErFPVHwhg/DsexF4KQWegJomds=";
+        inherit sha256;
       };
 
     # Add kernel patches here

--- a/nix/kernel-source.nix
+++ b/nix/kernel-source.nix
@@ -80,11 +80,11 @@ in
         # Compile with headers
         IKHEADERS = yes;
 
-        SLUB_DEBUG = yes;
-        DEBUG_MEMORY_INIT = yes;
-        KASAN = yes;
+        # SLUB_DEBUG = yes;
+        # DEBUG_MEMORY_INIT = yes;
+        # KASAN = yes;
 
-        # FRAME_WARN - warn at build time for stack frames larger tahn this.
+        # FRAME_WARN - warn at build time for stack frames larger than this.
 
         MAGIC_SYSRQ = yes;
 

--- a/nix/kernel-source.nix
+++ b/nix/kernel-source.nix
@@ -1,0 +1,182 @@
+# Credits: https://github.com/jordanisaacs/kernel-module-flake
+# Original Copyright Notice:
+
+# MIT License
+
+# Copyright (c) 2022 Jordan Isaacs
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+{ pkgs
+, lib ? pkgs.lib
+, enableGdb
+,
+}:
+let
+  version = "6.6.58";
+  localVersion = "-ukci";
+in
+{
+  kernelArgs = {
+    inherit enableGdb;
+
+    inherit version;
+    src =
+      pkgs.fetchurl {
+        url = "mirror://kernel/linux/kernel/v6.x/linux-${version}.tar.xz";
+        sha256 = "sha256-59+B5YjXD6tew+w7sErFPVHwhg/DsexF4KQWegJomds=";
+      };
+
+    # Add kernel patches here
+    kernelPatches =
+      let
+        fetchSet = lib.imap1 (i: hash: {
+          # name = " "kbuild-v${builtins.toString i}";
+          patch = pkgs.fetchpatch {
+            inherit hash;
+            url = "https://lore.kernel.org/rust-for-linux/20230109204520.539080-${builtins.toString i}-ojeda@kernel.org/raw";
+          };
+        });
+
+        patches = fetchSet [
+        ];
+      in
+      patches;
+
+    inherit localVersion;
+    modDirVersion = version + localVersion;
+  };
+  kernelConfig = {
+    # See https://github.com/NixOS/nixpkgs/blob/master/nixos/modules/system/boot/kernel_config.nix
+    structuredExtraConfig = with lib.kernel;
+      {
+        DEBUG_FS = yes;
+        DEBUG_KERNEL = yes;
+        DEBUG_MISC = yes;
+        DEBUG_BUGVERBOSE = yes;
+        DEBUG_BOOT_PARAMS = yes;
+        DEBUG_STACK_USAGE = yes;
+        DEBUG_SHIRQ = yes;
+        DEBUG_ATOMIC_SLEEP = yes;
+
+        IKCONFIG = yes;
+        IKCONFIG_PROC = yes;
+        # Compile with headers
+        IKHEADERS = yes;
+
+        SLUB_DEBUG = yes;
+        DEBUG_MEMORY_INIT = yes;
+        KASAN = yes;
+
+        # FRAME_WARN - warn at build time for stack frames larger tahn this.
+
+        MAGIC_SYSRQ = yes;
+
+        LOCALVERSION = freeform localVersion;
+
+        LOCK_STAT = yes;
+        PROVE_LOCKING = yes;
+
+        FTRACE = yes;
+        STACKTRACE = yes;
+        IRQSOFF_TRACER = yes;
+
+        KGDB = yes;
+        UBSAN = yes;
+        BUG_ON_DATA_CORRUPTION = yes;
+        SCHED_STACK_END_CHECK = yes;
+        UNWINDER_FRAME_POINTER = yes;
+        "64BIT" = yes;
+        SMP = yes;
+        IA32_EMULATION = yes;
+        PREEMPT_DYNAMIC = yes;
+
+        # initramfs/initrd support
+        BLK_DEV_INITRD = yes;
+
+        PRINTK = yes;
+        PRINTK_TIME = yes;
+        EARLY_PRINTK = yes;
+
+        # Support elf and #! scripts
+        BINFMT_ELF = yes;
+        BINFMT_SCRIPT = yes;
+
+        # Create a tmpfs/ramfs early at bootup.
+        DEVTMPFS = yes;
+        DEVTMPFS_MOUNT = yes;
+
+        TTY = yes;
+        SERIAL_8250 = yes;
+        SERIAL_8250_CONSOLE = yes;
+
+        PROC_FS = yes;
+        SYSFS = yes;
+
+        MODULES = yes;
+        MODULE_UNLOAD = yes;
+
+        # FW_LOADER = yes;
+
+        ##
+        SYSVIPC = yes;
+        NET = yes;
+        PACKET = yes;
+        INET = yes;
+        NETDEVICES = yes;
+        NET_CORE = yes;
+        ETHERNET = yes;
+        PCI = yes;
+        NET_VENDOR_INTEL = yes;
+        E1000 = yes;
+        UNIX = yes;
+
+        EXPERT = yes;
+        TMPFS = yes;
+        MEMFD_CREATE = yes;
+
+        PID_NS = yes;
+
+        SECCOMP = yes;
+
+        ## BPF
+        DEBUG_INFO_DWARF4 = yes;
+        DEBUG_INFO_BTF = yes;
+        BPF_SYSCALL = yes;
+        BPF_JIT = yes;
+        FUNCTION_TRACER = yes;
+        # Enable kprobes and kallsyms: https://www.kernel.org/doc/html/latest/trace/kprobes.html#configuring-kprobes
+        # Debug FS is be enabled (done above) to show registered kprobes in /sys/kernel/debug: https://www.kernel.org/doc/html/latest/trace/kprobes.html#the-kprobes-debugfs-interface
+        KPROBES = yes;
+        KALLSYMS_ALL = yes;
+      } // lib.optionalAttrs enableGdb {
+        DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT = yes;
+        GDB_SCRIPTS = yes;
+      };
+
+    # Flags that get passed to generate-config.pl
+    generateConfigFlags = {
+      # Ignores any config errors (eg unused config options)
+      ignoreConfigErrors = false;
+      # Build every available module
+      autoModules = false;
+      preferBuiltin = false;
+    };
+  };
+}

--- a/nix/tracexec.nix
+++ b/nix/tracexec.nix
@@ -1,0 +1,36 @@
+localFlake:
+
+{ lib, config, self, inputs, ... }:
+{
+  perSystem = { system, pkgs, ... }: {
+    packages.tracexec =
+      let
+        craneLib = localFlake.crane.mkLib pkgs;
+        cFilter = path: _type: builtins.match ".*\.[ch]$" path != null;
+        symlinkFilter = _path: type: type == "symlink";
+        sourceFilter = path: type:
+          (cFilter path type) || (symlinkFilter path type) || (craneLib.filterCargoSources path type);
+      in
+      craneLib.buildPackage {
+        src = lib.cleanSourceWith {
+          src = ./..;
+          filter = sourceFilter;
+          name = "source";
+        };
+        buildInputs = with pkgs; [
+          elfutils
+          zlib
+          libseccomp
+        ];
+        nativeBuildInputs = with pkgs; [
+          pkg-config
+          clang # For building eBPF
+        ];
+        hardeningDisable = [
+          "zerocallusedregs"
+        ];
+        # Don't store logs
+        TRACEXEC_DATA = "/tmp";
+      };
+  };
+}

--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -12,8 +12,9 @@ localFlake:
         kernel = self'.packages.kernel;
         extraBin = {
           tracexec = "${self'.packages.tracexec}/bin/tracexec";
+          strace = "${pkgs.strace}/bin/strace";
         };
-        storePaths = [pkgs.foot.terminfo];
+        storePaths = [ pkgs.foot.terminfo ];
       };
 
     packages.kernel =
@@ -46,5 +47,18 @@ localFlake:
         };
       in
       kernel;
+
+    packages.run-qemu = pkgs.writeScriptBin "run-qemu" ''
+      #!/usr/bin/env sh
+      sudo qemu-system-x86_64 \
+        -enable-kvm \
+        -m 2G \
+        -smp cores=4 \
+        -kernel ${self'.packages.kernel}/bzImage \
+        -initrd ${self'.packages.initramfs}/initrd.gz \
+        -device e1000,netdev=net0 \
+        -netdev user,id=net0,hostfwd=::10022-:22 \
+        -nographic -append "console=ttyS0"
+    '';
   };
 }

--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -1,0 +1,50 @@
+localFlake:
+
+{ lib, config, self, inputs, ... }:
+{
+  perSystem = { self', system, pkgs, ... }: {
+    packages.initramfs =
+      let
+        nixpkgs = localFlake.nixpkgs;
+        buildInitramfs = pkgs.callPackage ./initramfs.nix { };
+      in
+      buildInitramfs {
+        kernel = self'.packages.kernel;
+        extraBin = {
+          tracexec = "${self'.packages.tracexec}/bin/tracexec";
+        };
+        storePaths = [pkgs.foot.terminfo];
+      };
+
+    packages.kernel =
+      let
+        nixpkgs = localFlake.nixpkgs;
+        configureKernel = pkgs.callPackage ./kernel-configure.nix { };
+        buildKernel = pkgs.callPackage ./kernel-build.nix { };
+        kernelSource = pkgs.callPackage ./kernel-source.nix { enableGdb = false; };
+        inherit (kernelSource) kernelArgs kernelConfig;
+        linuxDev = pkgs.linuxPackagesFor kernelDrv;
+        kernel = linuxDev.kernel;
+        configfile = configureKernel {
+          inherit
+            (kernelConfig)
+            generateConfigFlags
+            structuredExtraConfig
+            ;
+          inherit kernel nixpkgs;
+        };
+        kernelDrv = buildKernel {
+          inherit
+            (kernelArgs)
+            src
+            modDirVersion
+            version
+            enableGdb
+            kernelPatches
+            ;
+          inherit configfile nixpkgs;
+        };
+      in
+      kernel;
+  };
+}

--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -3,77 +3,103 @@ localFlake:
 { lib, config, self, inputs, ... }:
 {
   perSystem = { self', system, pkgs, ... }: {
-    packages.initramfs =
+    packages =
       let
-        nixpkgs = localFlake.nixpkgs;
-        buildInitramfs = pkgs.callPackage ./initramfs.nix { };
-      in
-      buildInitramfs {
-        kernel = self'.packages.kernel;
-        extraBin = {
-          tracexec = "${self'.packages.tracexec}/bin/tracexec";
-          strace = "${pkgs.strace}/bin/strace";
-        };
-        storePaths = [ pkgs.foot.terminfo ];
-      };
-
-    packages.kernel =
-      let
+        sources = [{ name = "6.6lts"; version = "6.6.58"; sha256 = "sha256-59+B5YjXD6tew+w7sErFPVHwhg/DsexF4KQWegJomds="; }
+          { name = "6.1lts"; version = "6.1.113"; sha256 = "sha256-VK8QhxkvzFJQpCUUUf1hR2GFnT2WREncAjWOVYxEnjA="; }
+          { name = "6.11"; version = "6.11.5"; sha256 = "sha256-RxSFs7fy+2N72P49AJRMTBNcfY7gLzV/M2kLqrB1Kgc="; }];
         nixpkgs = localFlake.nixpkgs;
         configureKernel = pkgs.callPackage ./kernel-configure.nix { };
         buildKernel = pkgs.callPackage ./kernel-build.nix { };
-        kernelSource = pkgs.callPackage ./kernel-source.nix { enableGdb = false; };
-        inherit (kernelSource) kernelArgs kernelConfig;
-        linuxDev = pkgs.linuxPackagesFor kernelDrv;
-        kernel = linuxDev.kernel;
-        configfile = configureKernel {
-          inherit
-            (kernelConfig)
-            generateConfigFlags
-            structuredExtraConfig
-            ;
-          inherit kernel nixpkgs;
-        };
-        kernelDrv = buildKernel {
-          inherit
-            (kernelArgs)
-            src
-            modDirVersion
-            version
-            enableGdb
-            kernelPatches
-            ;
-          inherit configfile nixpkgs;
-        };
+        kernelNixConfig = source: pkgs.callPackage ./kernel-source.nix { enableGdb = false; inherit (source) version sha256; };
+        kernels = map
+          (source:
+            let
+              config = kernelNixConfig source;
+              inherit (config) kernelArgs kernelConfig;
+              configfile = configureKernel {
+                inherit
+                  (kernelConfig)
+                  generateConfigFlags
+                  structuredExtraConfig
+                  ;
+                inherit kernel nixpkgs;
+              };
+              linuxDev = pkgs.linuxPackagesFor kernelDrv;
+              kernel = linuxDev.kernel;
+              kernelDrv = buildKernel {
+                inherit
+                  (kernelArgs)
+                  src
+                  modDirVersion
+                  version
+                  enableGdb
+                  kernelPatches
+                  ;
+                inherit configfile nixpkgs;
+              };
+              buildInitramfs = pkgs.callPackage ./initramfs.nix { };
+            in
+            {
+              inherit kernel;
+              inherit (source) name;
+              initramfs = buildInitramfs {
+                inherit kernel;
+                extraBin = {
+                  tracexec = "${self'.packages.tracexec}/bin/tracexec";
+                  strace = "${pkgs.strace}/bin/strace";
+                };
+                storePaths = [ pkgs.foot.terminfo ];
+              };
+            })
+          sources;
       in
-      kernel;
+      {
+        run-qemu =
+          let
+            shellCases = lib.concatMapStrings
+              ({ name, kernel, initramfs }: ''
+                ${name})
+                  kernel="${kernel}"
+                  initrd="${initramfs}"
+                ;;
+              '')
+              kernels;
+          in
+          pkgs.writeScriptBin "run-qemu" ''
+            #!/usr/bin/env sh
 
-    packages.run-qemu = pkgs.writeScriptBin "run-qemu" ''
-      #!/usr/bin/env sh
-      sudo qemu-system-x86_64 \
-        -enable-kvm \
-        -m 2G \
-        -smp cores=4 \
-        -kernel ${self'.packages.kernel}/bzImage \
-        -initrd ${self'.packages.initramfs}/initrd.gz \
-        -device e1000,netdev=net0 \
-        -netdev user,id=net0,hostfwd=::10022-:22 \
-        -nographic -append "console=ttyS0"
-    '';
+            case "$1" in
+              ${shellCases}
+              *)
+                echo "Invalid argument!"
+                exit 1
+            esac
 
-    packages.test-qemu = pkgs.writeScriptBin "test-qemu" ''
-      #!/usr/bin/env sh
-      ssh="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@127.0.0.1 -p 10022"
+            sudo qemu-system-x86_64 \
+              -enable-kvm \
+              -m 2G \
+              -smp cores=4 \
+              -kernel "$kernel"/bzImage \
+              -initrd "$initrd"/initrd.gz \
+              -device e1000,netdev=net0 \
+              -netdev user,id=net0,hostfwd=::10022-:22 \
+              -nographic -append "console=ttyS0"
+          '';
+        test-qemu = pkgs.writeScriptBin "test-qemu" ''
+          #!/usr/bin/env sh
+          ssh="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@127.0.0.1 -p 10022"
 
-      # Wait for the qemu virtual machine to start...
-      for i in $(seq 1 12); do
-        [ $i -gt 1 ] && sleep 5;
-        $ssh true && break;
-      done;
+          # Wait for the qemu virtual machine to start...
+          for i in $(seq 1 12); do
+            [ $i -gt 1 ] && sleep 5;
+            $ssh true && break;
+          done;
 
-      # Try to load eBPF module:
-      $ssh tracexec ebpf log -- ls
-      exit $?
-    '';
+          # Try to load eBPF module:
+          $ssh tracexec ebpf log -- ls
+          exit $?
+        '';
+      };
   };
 }

--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -60,5 +60,20 @@ localFlake:
         -netdev user,id=net0,hostfwd=::10022-:22 \
         -nographic -append "console=ttyS0"
     '';
+
+    packages.test-qemu = pkgs.writeScriptBin "test-qemu" ''
+      #!/usr/bin/env sh
+      ssh="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@127.0.0.1 -p 10022"
+
+      # Wait for the qemu virtual machine to start...
+      for i in $(seq 1 12); do
+        [ $i -gt 1 ] && sleep 5;
+        $ssh true && break;
+      done;
+
+      # Try to load eBPF module:
+      $ssh tracexec ebpf log -- ls
+      exit $?
+    '';
   };
 }

--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -47,6 +47,7 @@ localFlake:
                 inherit kernel;
                 extraBin = {
                   tracexec = "${self'.packages.tracexec}/bin/tracexec";
+                  tracexec_no_rcu_kfuncs = "${self'.packages.tracexec_no_rcu_kfuncs}/bin/tracexec";
                   strace = "${pkgs.strace}/bin/strace";
                 };
                 storePaths = [ pkgs.foot.terminfo ];

--- a/src/bpf/common.h
+++ b/src/bpf/common.h
@@ -4,10 +4,6 @@
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
 
-// KFuncs
-
-extern void bpf_rcu_read_lock(void) __ksym;
-extern void bpf_rcu_read_unlock(void) __ksym;
 
 // Macros
 
@@ -62,5 +58,26 @@ struct sys_enter_exec_args {
   const u8 *const *argv;
   const u8 *const *envp;
 };
+
+// Compatibility Shims
+
+#ifndef NO_RCU_KFUNCS
+extern void bpf_rcu_read_lock(void) __ksym;
+extern void bpf_rcu_read_unlock(void) __ksym;
+#endif
+
+int __always_inline rcu_read_lock() {
+#ifndef NO_RCU_KFUNCS
+  bpf_rcu_read_lock();
+#endif
+  return 0;
+}
+
+int __always_inline rcu_read_unlock() {
+#ifndef NO_RCU_KFUNCS
+  bpf_rcu_read_unlock();
+#endif
+  return 0;
+}
 
 #endif


### PR DESCRIPTION
- Fix non-FHS compatibility issues BTW
- Add nix flake that
  - builds and tests tracexec
  - includes ukci(Userspace <-> Kernel CI) that builds different kernel versions
- Fix 6.1 kernel compatibility by adding a new feature `ebpf-no-rcu-kfuncs`.
 
TODO: Add ukci to GitHub Actions