### PR TITLE
ci: split nix ci from main ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,22 +75,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Run clippy
         run: cargo clippy
-  nix:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - run: |
-        sudo apt-get update -y
-        sudo apt-get install -y qemu-kvm
-    - uses: cachix/install-nix-action@v27
-      with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - uses: DeterminateSystems/magic-nix-cache-action@v2
-    # Build and test tracexec
-    # Also builds kernels
-    - run: nix build
-    # Run Userspace<->Kernel CI
-    - run: nix run '.#ukci'
   check_and_test:
     strategy:
       fail-fast: false

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,34 @@
+name: Continuous Integration (Nix)
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+  merge_group:
+
+# ensure that the workflow is only triggered once per PR,  subsequent pushes to the PR will cancel
+# and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: |
+        sudo apt-get update -y
+        sudo apt-get install -y qemu-kvm
+    - uses: cachix/install-nix-action@v27
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - uses: DeterminateSystems/magic-nix-cache-action@v2
+    # Build and test tracexec
+    # Also builds kernels
+    - run: nix build
+    # Run Userspace<->Kernel CI
+    - run: nix run '.#ukci'


### PR DESCRIPTION
This seems necessary to mitigate the no space on disk error.