### PR TITLE
perf: replace `static ref` & `format!` with `const` & `concat!`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,9 +826,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",

--- a/src/log.rs
+++ b/src/log.rs
@@ -27,14 +27,14 @@ pub use tracing::*;
 
 use crate::{cli::config::project_directory, tui::restore_tui};
 
+const LOG_FILE: &str = concat!(env!("CARGO_PKG_NAME"), ".log");
+
 lazy_static! {
-  pub static ref PROJECT_NAME: String = env!("CARGO_CRATE_NAME").to_uppercase();
   pub static ref DATA_FOLDER: Option<PathBuf> =
-    std::env::var(format!("{}_DATA", PROJECT_NAME.clone()))
+    std::env::var(concat!(env!("CARGO_CRATE_NAME"), "_DATA").to_uppercase())
       .ok()
       .map(PathBuf::from);
-  pub static ref LOG_ENV: String = format!("{}_LOGLEVEL", PROJECT_NAME.clone());
-  pub static ref LOG_FILE: String = format!("{}.log", env!("CARGO_PKG_NAME"));
+  pub static ref LOG_ENV: String = concat!(env!("CARGO_CRATE_NAME"), "_LOGLEVEL").to_uppercase();
 }
 
 pub fn get_data_dir() -> PathBuf {
@@ -51,7 +51,7 @@ pub fn get_data_dir() -> PathBuf {
 pub fn initialize_logging() -> Result<()> {
   let directory = get_data_dir();
   std::fs::create_dir_all(directory.clone())?;
-  let log_path = directory.join(LOG_FILE.clone());
+  let log_path = directory.join(LOG_FILE);
   let log_file = std::fs::File::create(log_path)?;
   let file_subscriber = tracing_subscriber::fmt::layer()
     .with_file(true)
@@ -69,9 +69,8 @@ pub fn initialize_logging() -> Result<()> {
   } else if std::env::var("RUST_LOG").is_ok() {
     file_subscriber.with_filter(tracing_subscriber::filter::EnvFilter::from_env("RUST_LOG"))
   } else {
-    file_subscriber.with_filter(tracing_subscriber::filter::EnvFilter::new(format!(
-      "{}=info",
-      env!("CARGO_CRATE_NAME")
+    file_subscriber.with_filter(tracing_subscriber::filter::EnvFilter::new(concat!(
+      env!("CARGO_CRATE_NAME"), "=info"
     )))
   };
 


### PR DESCRIPTION
- Replace `static ref` & `format!` with `const` & `concat!` to enhance performance.