### PR TITLE
Event retention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -715,6 +715,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ftree"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae0379499242d3b9355c5069b43b9417def8c9b09903b930db1fe49318dc9e9"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +894,15 @@ checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
  "hashbrown",
+]
+
+[[package]]
+name = "indexset"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20305cb9171bd8657ee6e0c800926b181d91bca3523fca32e835f2fd7f4e1875"
+dependencies = [
+ "ftree",
 ]
 
 [[package]]
@@ -2199,7 +2217,7 @@ dependencies = [
  "filterable-enum",
  "futures",
  "hashbrown",
- "indexmap",
+ "indexset",
  "itertools 0.14.0",
  "kxxt-owo-colors",
  "libbpf-cargo",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,15 +112,6 @@ dependencies = [
  "parking_lot",
  "wl-clipboard-rs",
  "x11rb",
-]
-
-[[package]]
-name = "arcstr"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -207,6 +209,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "ad0cf6e91fde44c773c6ee7ec6bba798504641a8bc2eb7e37a04ffbf4dfaa55a"
 dependencies = [
  "shlex",
 ]
@@ -594,6 +602,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
+name = "erased-serde"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24e2389d65ab4fab27dc2a5de7b191e1f6617d1f1c8855c0dc569c94a4cbb18d"
+dependencies = [
+ "serde",
+ "typeid",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -877,9 +895,9 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "instability"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "894813a444908c0c8c0e221b041771d107c4a21de1d317dc49bcc66e3c9e5b3f"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
 dependencies = [
  "darling",
  "indoc",
@@ -1061,9 +1079,12 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "3d6ea2a48c204030ee31a7d7fc72c93294c92fe87ecb1789881c9543516e1a0d"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -1384,6 +1405,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "predicates"
 version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1447,6 +1477,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -1718,6 +1778,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_fmt"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d4ddca14104cd60529e8c7f7ba71a2c8acd8f7f5cfcdc2faf97eeb7c3010a4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1894,6 +1963,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "sval"
+version = "2.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6dc0f9830c49db20e73273ffae9b5240f63c42e515af1da1fceefb69fceafd8"
+
+[[package]]
+name = "sval_buffer"
+version = "2.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "429922f7ad43c0ef8fd7309e14d750e38899e32eb7e8da656ea169dd28ee212f"
+dependencies = [
+ "sval",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_dynamic"
+version = "2.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f16ff5d839396c11a30019b659b0976348f3803db0626f736764c473b50ff4"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_fmt"
+version = "2.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c01c27a80b6151b0557f9ccbe89c11db571dc5f68113690c1e028d7e974bae94"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_json"
+version = "2.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0deef63c70da622b2a8069d8600cf4b05396459e665862e7bdb290fd6cf3f155"
+dependencies = [
+ "itoa",
+ "ryu",
+ "sval",
+]
+
+[[package]]
+name = "sval_nested"
+version = "2.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a39ce5976ae1feb814c35d290cf7cf8cd4f045782fe1548d6bc32e21f6156e9f"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_ref",
+]
+
+[[package]]
+name = "sval_ref"
+version = "2.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb7c6ee3751795a728bc9316a092023529ffea1783499afbc5c66f5fabebb1fa"
+dependencies = [
+ "sval",
+]
+
+[[package]]
+name = "sval_serde"
+version = "2.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a5572d0321b68109a343634e3a5d576bf131b82180c6c442dee06349dfc652a"
+dependencies = [
+ "serde",
+ "sval",
+ "sval_nested",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2035,7 +2182,6 @@ name = "tracexec"
 version = "0.8.2"
 dependencies = [
  "arboard",
- "arcstr",
  "assert_cmd",
  "atoi",
  "better-panic",
@@ -2062,6 +2208,7 @@ dependencies = [
  "nix 0.29.0",
  "paste",
  "predicates",
+ "rand",
  "ratatui",
  "regex-cursor",
  "rstest 0.24.0",
@@ -2088,6 +2235,7 @@ dependencies = [
  "unicode-segmentation",
  "unicode-width 0.1.14",
  "vt100",
+ "weak-table",
 ]
 
 [[package]]
@@ -2250,6 +2398,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typeid"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e13db2e0ccd5e14a544e8a246ba2312cd25223f616442d7f2cb0e3db614236e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,6 +2449,48 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "value-bag"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef4c4aa54d5d05a279399bfa921ec387b7aba77caf7a682ae8d86785b8fdad2"
+dependencies = [
+ "value-bag-serde1",
+ "value-bag-sval2",
+]
+
+[[package]]
+name = "value-bag-serde1"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bb773bd36fd59c7ca6e336c94454d9c66386416734817927ac93d81cb3c5b0b"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_fmt",
+]
+
+[[package]]
+name = "value-bag-sval2"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a916a702cac43a88694c97657d449775667bcd14b70419441d05b7fea4a83a"
+dependencies = [
+ "sval",
+ "sval_buffer",
+ "sval_dynamic",
+ "sval_fmt",
+ "sval_json",
+ "sval_ref",
+ "sval_serde",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vsprintf"
@@ -2425,6 +2621,15 @@ dependencies = [
  "dlib",
  "log",
  "pkg-config",
+]
+
+[[package]]
+name = "weak-table"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "323f4da9523e9a669e1eaf9c6e763892769b1d38c623913647bfdc1532fe4549"
+dependencies = [
+ "ahash",
 ]
 
 [[package]]
@@ -2599,9 +2804,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.22"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39281189af81c07ec09db316b302a3e67bf9bd7cbf6c820b50e35fee9c2fa980"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
@@ -2642,3 +2847,24 @@ name = "x11rb-protocol"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2198,6 +2198,7 @@ dependencies = [
  "filedescriptor",
  "filterable-enum",
  "futures",
+ "hashbrown",
  "indexmap",
  "itertools 0.14.0",
  "kxxt-owo-colors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,6 @@ tui-prompts = "0.5.0"
 unicode-segmentation = "1.11.0"
 unicode-width = "0.1.12"
 serial_test = { version = "3.1.1", features = ["file_locks"] }
-arcstr = { version = "1.2.0", features = ["serde"] }
 clap_complete = "4.5.2"
 regex-cursor = { version = "0.1.4", default-features = false }
 shell-words = "1.1.0"
@@ -79,12 +78,15 @@ libbpf-rs = { version = "0.24.6", optional = true, default-features = false }
 # libbpf-sys exists here because we want to control its features
 libbpf-sys = { version = "1", optional = true, default-features = false }
 libseccomp = { version = "0.3.0", optional = true }
+weak-table = { version = "0.3.2", default-features = false, features = ["ahash"] }
+rand = "0.8.5"
 # tui-prompts = { version = "0.3.11", path = "../../contrib/tui-prompts" }
 # tui-popup = { version = "0.3.0", path = "../../contrib/tui-popup" }
 
 [dev-dependencies]
 assert_cmd = "2.0.14"
 predicates = "3.1.0"
+
 rstest = "0.24.0"
 tracing-test = "0.2.4"
 
@@ -127,3 +129,7 @@ path = "fixtures/empty-argv.rs"
 name = "corrupted-envp"
 path = "fixtures/corrupted-envp.rs"
 
+
+[[bin]]
+name = "exec-stress"
+path = "fixtures/exec-stress.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ libbpf-sys = { version = "1", optional = true, default-features = false }
 libseccomp = { version = "0.3.0", optional = true }
 weak-table = { version = "0.3.2", default-features = false, features = ["ahash"] }
 rand = "0.8.5"
+hashbrown = "0.15.2"
 # tui-prompts = { version = "0.3.11", path = "../../contrib/tui-prompts" }
 # tui-popup = { version = "0.3.0", path = "../../contrib/tui-popup" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ tui-popup = "0.6.0"
 thiserror = "1.0.59"
 tui-scrollview = "0.5.0"
 bitflags = "2.5.0"
-indexmap = "2.2.6"
 tui-prompts = "0.5.0"
 unicode-segmentation = "1.11.0"
 unicode-width = "0.1.12"
@@ -81,6 +80,7 @@ libseccomp = { version = "0.3.0", optional = true }
 weak-table = { version = "0.3.2", default-features = false, features = ["ahash"] }
 rand = "0.8.5"
 hashbrown = "0.15.2"
+indexset = "0.10.0"
 # tui-prompts = { version = "0.3.11", path = "../../contrib/tui-prompts" }
 # tui-popup = { version = "0.3.0", path = "../../contrib/tui-popup" }
 

--- a/config.toml
+++ b/config.toml
@@ -60,6 +60,9 @@
 # Target frame rate. A positive floating-point number
 # frame_rate = 60.0
 
+# Max number of events to keep in TUI. (0=unlimited)
+# max_events = 1_000_000
+
 #
 # Config for Log mode
 #

--- a/fixtures/exec-stress.rs
+++ b/fixtures/exec-stress.rs
@@ -1,0 +1,33 @@
+use std::ffi::CString;
+
+use nix::unistd::execv;
+use rand::{distributions::Alphanumeric, Rng};
+
+// A stress test.
+// It will exec itself with random strings as arguments for n times
+fn main() {
+  let mut args = std::env::args().skip(1);
+  let n: u64 = args
+    .next()
+    .expect("missing n")
+    .parse()
+    .expect("cannot parse n");
+  if n == 0 {
+    // nix::sys::signal::raise(nix::sys::signal::SIGSTOP);
+    return;
+  }
+  let mut rand_args = vec![
+    CString::new("Hello").unwrap(),
+    CString::new((n - 1).to_string()).unwrap(),
+  ];
+  rand_args.extend((0..10).map(|_| unsafe {
+    CString::from_vec_unchecked(
+      rand::thread_rng()
+        .sample_iter(&Alphanumeric)
+        .take(512)
+        .chain(Some(0))
+        .collect::<Vec<u8>>(),
+    )
+  }));
+  execv(c"/proc/self/exe", &rand_args).unwrap();
+}

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,52 +1,142 @@
+use serde::{Serialize, Serializer};
 use std::{
-  collections::HashSet,
-  ops::{Deref, DerefMut},
+  borrow::Cow,
+  fmt::{Debug, Display},
+  ops::Deref,
+  sync::{Arc, LazyLock, Weak},
 };
+use weak_table::WeakHashSet;
 
-use arcstr::ArcStr;
+#[derive(Clone)]
+#[repr(transparent)]
+pub struct ArcStr(Arc<str>);
+
+impl ArcStr {
+  pub fn as_str(&self) -> &str {
+    &self.0
+  }
+}
+
+impl Deref for ArcStr {
+  type Target = str;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl AsRef<str> for ArcStr {
+  fn as_ref(&self) -> &str {
+    &self.0
+  }
+}
+
+impl<T> PartialEq<T> for ArcStr
+where
+  T: AsRef<str>,
+{
+  fn eq(&self, other: &T) -> bool {
+    &*self.0 == other.as_ref()
+  }
+}
+
+impl Eq for ArcStr {}
+
+impl From<Arc<str>> for ArcStr {
+  fn from(value: Arc<str>) -> Self {
+    Self(value)
+  }
+}
+
+impl From<ArcStr> for Cow<'_, str> {
+  fn from(value: ArcStr) -> Self {
+    Self::Owned(value.to_string())
+  }
+}
+
+impl Serialize for ArcStr {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: Serializer,
+  {
+    serializer.serialize_str(&self.0)
+  }
+}
+
+impl std::hash::Hash for ArcStr {
+  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    self.0.hash(state);
+  }
+}
+
+impl PartialOrd for ArcStr {
+  fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    Some(self.0.cmp(&other.0))
+  }
+}
+
+impl Ord for ArcStr {
+  fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    self.0.cmp(&other.0)
+  }
+}
+
+impl Display for ArcStr {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    Display::fmt(&self.0, f)
+  }
+}
+
+impl Debug for ArcStr {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    Debug::fmt(&self.0, f)
+  }
+}
+
+impl From<&str> for ArcStr {
+  fn from(value: &str) -> Self {
+    Arc::<str>::from(value).into()
+  }
+}
+
+impl Default for ArcStr {
+  fn default() -> Self {
+    DEFAULT_ARCSTR.clone()
+  }
+}
+
+static DEFAULT_ARCSTR: LazyLock<ArcStr> = LazyLock::new(|| "".into());
 
 pub struct StringCache {
-  cache: HashSet<ArcStr>,
+  inner: WeakHashSet<Weak<str>>,
 }
 
 impl StringCache {
   pub fn new() -> Self {
     Self {
-      cache: HashSet::new(),
-    }
-  }
-
-  pub fn get_or_insert_owned(&mut self, s: String) -> ArcStr {
-    if let Some(s) = self.cache.get(s.as_str()) {
-      s.clone()
-    } else {
-      let arc = ArcStr::from(s);
-      self.cache.insert(arc.clone());
-      arc
+      inner: WeakHashSet::new(),
     }
   }
 
   pub fn get_or_insert(&mut self, s: &str) -> ArcStr {
-    if let Some(s) = self.cache.get(s) {
-      s.clone()
+    if let Some(s) = self.inner.get(s) {
+      s.into()
     } else {
-      let arc = ArcStr::from(s);
-      self.cache.insert(arc.clone());
-      arc
+      let arc: Arc<str> = Arc::from(s);
+      self.inner.insert(arc.clone());
+      arc.into()
     }
   }
-}
 
-impl Deref for StringCache {
-  type Target = HashSet<ArcStr>;
-
-  fn deref(&self) -> &Self::Target {
-    &self.cache
-  }
-}
-
-impl DerefMut for StringCache {
-  fn deref_mut(&mut self) -> &mut Self::Target {
-    &mut self.cache
+  // Probably this is not necessary.
+  // I don't think we can find a way to turn a String into Arc<str> in-place.
+  pub fn get_or_insert_owned(&mut self, s: String) -> ArcStr {
+    if let Some(s) = self.inner.get(s.as_str()) {
+      s.into()
+    } else {
+      let arc: Arc<str> = Arc::from(s);
+      self.inner.insert(arc.clone());
+      arc.into()
+    }
   }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -32,7 +32,7 @@ pub struct PtraceArgs {
   pub tracer_delay: Option<u64>,
 }
 
-#[derive(Args, Debug, Default, Clone)]
+#[derive(Args, Debug, Default, Clone, Copy)]
 pub struct ModifierArgs {
   #[clap(long, help = "Only show successful calls", default_value_t = false)]
   pub successful_only: bool,
@@ -420,6 +420,12 @@ pub struct TuiModeArgs {
     value_parser = frame_rate_parser
   )]
   pub frame_rate: Option<f64>,
+  #[clap(
+    long,
+    short = 'm',
+    help = "Max number of events to keep in TUI (0=unlimited)"
+  )]
+  pub max_events: Option<u64>,
 }
 
 #[derive(Args, Debug, Default, Clone)]
@@ -444,6 +450,7 @@ impl TuiModeArgs {
     self.active_pane = self.active_pane.or(config.active_pane);
     self.layout = self.layout.or(config.layout);
     self.frame_rate = self.frame_rate.or(config.frame_rate);
+    self.max_events = self.max_events.or(config.max_events);
     self.follow |= config.follow.unwrap_or_default();
     if (!self.terminate_on_exit) && (!self.kill_on_exit) {
       match config.exit_handling {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -74,6 +74,7 @@ pub struct TuiModeConfig {
   pub layout: Option<AppLayout>,
   #[serde(default, deserialize_with = "deserialize_frame_rate")]
   pub frame_rate: Option<f64>,
+  pub max_events: Option<u64>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -7,7 +7,7 @@ use std::{
   sync::{atomic::AtomicU64, Arc},
 };
 
-use arcstr::ArcStr;
+use crate::cache::ArcStr;
 use clap::ValueEnum;
 use crossterm::event::KeyEvent;
 use either::Either;

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,7 +1,7 @@
 //! Data structures for export command
 use std::{error::Error, sync::Arc};
 
-use arcstr::ArcStr;
+use crate::cache::ArcStr;
 use nix::libc::pid_t;
 use serde::Serialize;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -204,7 +204,7 @@ async fn main() -> color_eyre::Result<()> {
       let tracer = Arc::new(tracer::Tracer::new(
         tracer_mode,
         tracing_args.clone(),
-        modifier_args.clone(),
+        modifier_args,
         ptrace_args,
         tracer_event_args,
         baseline.clone(),
@@ -269,7 +269,7 @@ async fn main() -> color_eyre::Result<()> {
           foreground: tracing_args.foreground(),
         },
         tracing_args.clone(),
-        modifier_args.clone(),
+        modifier_args,
         ptrace_args,
         TracerEventArgs::all(),
         baseline.clone(),

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -16,7 +16,7 @@ use crate::{
   tracer::state::{ExecData, ProcessState},
 };
 
-use arcstr::ArcStr;
+use crate::cache::ArcStr;
 use itertools::chain;
 use nix::{fcntl::OFlag, libc::ENOENT, unistd::Pid};
 use owo_colors::{OwoColorize, Style};

--- a/src/proc.rs
+++ b/src/proc.rs
@@ -12,7 +12,7 @@ use std::{
   sync::{Arc, LazyLock, RwLock},
 };
 
-use arcstr::ArcStr;
+use crate::cache::ArcStr;
 use filedescriptor::AsRawFileDescriptor;
 use owo_colors::OwoColorize;
 

--- a/src/regex.rs
+++ b/src/regex.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 /// Regex and regex-cursor related code
 use regex_cursor::Cursor;
 
@@ -302,7 +304,7 @@ pub struct ArgvCursor<'a, T> {
   offset: usize,
 }
 
-pub const SPACE: OutputMsg = OutputMsg::Ok(arcstr::literal!(" "));
+pub static SPACE: LazyLock<OutputMsg> = LazyLock::new(|| OutputMsg::Ok(" ".into()));
 
 impl<'a, T> ArgvCursor<'a, T>
 where
@@ -380,14 +382,12 @@ where
 #[cfg(test)]
 mod cursor_tests {
   use super::*;
-  use arcstr::ArcStr;
-
-  pub const SPACE: ArcStr = arcstr::literal!(" ");
+  use crate::cache::ArcStr;
 
   #[test]
   fn smoke_test() {
     let single = vec![ArcStr::from("abc")];
-    let separator = SPACE;
+    let separator = " ".into();
     let mut cursor = ArgvCursor::new(single.as_slice(), &separator);
     assert_eq!(cursor.chunk(), "abc".as_bytes());
     assert!(!cursor.advance());

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -9,7 +9,7 @@ use std::{
   time::Duration,
 };
 
-use arcstr::ArcStr;
+use crate::cache::ArcStr;
 use cfg_if::cfg_if;
 use either::Either;
 use enumflags2::BitFlags;

--- a/src/tracer/inspect.rs
+++ b/src/tracer/inspect.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, ffi::CString};
 
-use arcstr::ArcStr;
+use crate::cache::ArcStr;
 use nix::{
   errno::Errno,
   sys::ptrace::{self, AddressType},

--- a/src/tracer/state.rs
+++ b/src/tracer/state.rs
@@ -5,7 +5,7 @@ use std::{
   sync::Arc,
 };
 
-use arcstr::ArcStr;
+use crate::cache::ArcStr;
 use nix::unistd::Pid;
 use regex_cursor::engines::pikevm::{self, PikeVM};
 use strum::IntoStaticStr;

--- a/src/tracer/state.rs
+++ b/src/tracer/state.rs
@@ -21,7 +21,7 @@ use crate::{
 use super::BreakPointHit;
 
 pub struct ProcessStateStore {
-  processes: HashMap<Pid, Vec<ProcessState>>,
+  processes: HashMap<Pid, Option<ProcessState>>,
 }
 
 #[derive(Debug)]
@@ -110,18 +110,18 @@ impl ProcessStateStore {
   }
 
   pub fn insert(&mut self, state: ProcessState) {
-    self.processes.entry(state.pid).or_default().push(state);
+    self.processes.entry(state.pid).or_default().replace(state);
   }
 
   pub fn get_current_mut(&mut self, pid: Pid) -> Option<&mut ProcessState> {
     // The last process in the vector is the current process
     // println!("Getting {pid}");
-    self.processes.get_mut(&pid)?.last_mut()
+    self.processes.get_mut(&pid)?.as_mut()
   }
 
   pub fn get_current(&self, pid: Pid) -> Option<&ProcessState> {
     // The last process in the vector is the current process
-    self.processes.get(&pid)?.last()
+    self.processes.get(&pid)?.as_ref()
   }
 }
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -67,6 +67,8 @@ use super::{
   Tui,
 };
 
+pub const DEFAULT_MAX_EVENTS: u64 = 1_000_000;
+
 #[derive(
   Debug, Clone, Copy, PartialEq, Eq, Default, ValueEnum, Display, Deserialize, Serialize,
 )]
@@ -122,7 +124,12 @@ impl App {
       }
     }
     Ok(Self {
-      event_list: EventList::new(baseline, tui_args.follow, modifier_args.to_owned()),
+      event_list: EventList::new(
+        baseline,
+        tui_args.follow,
+        modifier_args.to_owned(),
+        tui_args.max_events.unwrap_or(DEFAULT_MAX_EVENTS),
+      ),
       printer_args: PrinterArgs::from_cli(tracing_args, modifier_args),
       split_percentage: if pty_master.is_some() { 50 } else { 100 },
       term: if let Some(pty_master) = pty_master {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -448,7 +448,6 @@ impl App {
                   debug!("Received tracee spawn event: {pid}");
                   self.root_pid = Some(*pid);
                 }
-                debug_assert_eq!(e.id, self.event_list.len() as u64);
                 self.event_list.push(e.id, e.details);
                 if self.event_list.is_following() {
                   action_tx.send(Action::ScrollToBottom)?;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -392,8 +392,8 @@ impl App {
                   KeyCode::Char('c')
                     if ke.modifiers == KeyModifiers::NONE && self.clipboard.is_some() =>
                   {
-                    if let Some(selected) = self.event_list.selection() {
-                      action_tx.send(Action::ShowCopyDialog(selected.details.clone()))?;
+                    if let Some((details, _)) = self.event_list.selection() {
+                      action_tx.send(Action::ShowCopyDialog(details))?;
                     }
                   }
                   KeyCode::Char('l') if ke.modifiers == KeyModifiers::ALT => {
@@ -416,9 +416,9 @@ impl App {
                     action_tx.send(Action::SetActivePopup(ActivePopup::Help))?;
                   }
                   KeyCode::Char('v') if ke.modifiers == KeyModifiers::NONE => {
-                    if let Some(selected) = self.event_list.selection() {
+                    if let Some((event, status)) = self.event_list.selection() {
                       action_tx.send(Action::SetActivePopup(ActivePopup::ViewDetails(
-                        DetailsPopupState::new(selected, self.event_list.baseline.clone()),
+                        DetailsPopupState::new(event, status, self.event_list.baseline.clone()),
                       )))?;
                     }
                   }
@@ -449,7 +449,7 @@ impl App {
                   self.root_pid = Some(*pid);
                 }
                 debug_assert_eq!(e.id, self.event_list.len() as u64);
-                self.event_list.push(e.details);
+                self.event_list.push(e.id, e.details);
                 if self.event_list.is_following() {
                   action_tx.send(Action::ScrollToBottom)?;
                 }

--- a/src/tui/event_line.rs
+++ b/src/tui/event_line.rs
@@ -54,6 +54,20 @@ impl Display for EventLine {
   }
 }
 
+impl EventLine {
+  pub fn toggle_cwd_mask(&mut self) {
+    if let Some(mask) = &mut self.cwd_mask {
+      mask.toggle(&mut self.line);
+    }
+  }
+
+  pub fn toggle_env_mask(&mut self) {
+    if let Some(mask) = &mut self.env_mask {
+      mask.toggle(&mut self.line);
+    }
+  }
+}
+
 // Original Copyright Notice for the following code:
 
 // Copyright (c) 2024 Pascal Kuthe


### PR DESCRIPTION
- Use `Arc<str>` instead of `arcstr::ArcStr` so that we get a weak count for doing garbage collection
- Use weak table for garbage collection
- Add `max_events` option/config for event retention
- Don't keep stale process states in tracer.