### PR TITLE
fix: use pipe2 to signal tracee to proceed to exec

### DIFF
--- a/src/pty.rs
+++ b/src/pty.rs
@@ -586,13 +586,13 @@ fn spawn_command_from_pty_fd(
         _ = libc::sigprocmask(libc::SIG_SETMASK, &empty_set, std::ptr::null_mut());
       }
 
+      pre_exec(&cmd.program).unwrap();
+
       close_random_fds();
 
       if let Some(mask) = configured_umask {
         _ = unsafe { libc::umask(mask) };
       }
-
-      pre_exec(&cmd.program).unwrap();
 
       execv(
         &CString::new(cmd.program.into_os_string().into_vec()).unwrap(),


### PR DESCRIPTION
Previously we raise SIGSTOP in tracee and then waitpid in tracer before seizing it, which yields a group stop(I think this is actually an UNDOCUMENTED behavior) after seizing. It hits some ptrace quirks.

For example, some child processes forked off after exec might caught this phantom ptrace group stop and hangs.

So this patch instead uses a pipe between tracer and root tracee to communicate when to proceed to exec.