### PR TITLE
Drop compile-time seccomp-bpf feature gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,6 @@ jobs:
             arch: x86_64
             libpath: usr/lib/x86_64-linux-gnu
             no-default-features: true
-            args: '-F seccomp-bpf'
           - os: ubuntu-24.04
             os-arch: amd64
             target: x86_64-unknown-linux-gnu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,15 +62,14 @@ jobs:
             target: riscv64gc-unknown-linux-gnu
             arch: riscv64
             libpath: usr/lib/riscv64-linux-gnu
-            no-default-features: true
-            features: ebpf,vendored-libbpf
+            no-default-features: false
           - os: ubuntu-24.04
             os-arch: riscv64
             target: riscv64gc-unknown-linux-gnu
             arch: riscv64
             libpath: usr/lib/riscv64-linux-gnu
-            no-default-features: true
-            features: ebpf,static,vendored
+            no-default-features: false
+            features: static,vendored
             artifact-suffix: -static
             rust_flags: -C target-feature=+crt-static
             static_libseccomp: true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ serde_json = "1.0.120"
 libbpf-rs = { version = "0.24.6", optional = true, default-features = false }
 # libbpf-sys exists here because we want to control its features
 libbpf-sys = { version = "1", optional = true, default-features = false }
-libseccomp = { version = "0.3.0", optional = true }
+libseccomp = "0.3.0"
 weak-table = { version = "0.3.2", default-features = false, features = ["ahash"] }
 rand = "0.8.5"
 hashbrown = "0.15.2"
@@ -97,8 +97,7 @@ libbpf-cargo = { version = "0.24.6", default-features = false }
 
 [features]
 default = ["recommended", "vendored-libbpf"]
-recommended = ["seccomp-bpf", "ebpf"]
-seccomp-bpf = ["dep:libseccomp"]
+recommended = ["ebpf"]
 ebpf = ["dep:libbpf-rs", "dep:libbpf-sys"]
 # The ebpf-debug feature is not meant for end users.
 # This feature also has a bug:

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -11,7 +11,6 @@ use crate::{
   tui::app::AppLayout,
 };
 
-#[cfg(feature = "seccomp-bpf")]
 use super::options::SeccompBpf;
 use super::{
   config::{
@@ -22,7 +21,6 @@ use super::{
 
 #[derive(Args, Debug, Default, Clone)]
 pub struct PtraceArgs {
-  #[cfg(feature = "seccomp-bpf")]
   #[clap(long, help = "Controls whether to enable seccomp-bpf optimization, which greatly improves performance", default_value_t = SeccompBpf::Auto)]
   pub seccomp_bpf: SeccompBpf,
   #[clap(
@@ -62,7 +60,6 @@ pub struct ModifierArgs {
 impl PtraceArgs {
   pub fn merge_config(&mut self, config: PtraceConfig) {
     // seccomp-bpf
-    #[cfg(feature = "seccomp-bpf")]
     if let Some(setting) = config.seccomp_bpf {
       if self.seccomp_bpf == SeccompBpf::Auto {
         self.seccomp_bpf = setting;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,6 @@ mod proc;
 mod ptrace;
 mod pty;
 mod regex;
-#[cfg(feature = "seccomp-bpf")]
 mod seccomp;
 mod tracee;
 mod tracer;

--- a/src/ptrace/tracer/test.rs
+++ b/src/ptrace/tracer/test.rs
@@ -141,7 +141,9 @@ async fn tracer_decodes_proc_self_exe(
 #[file_serial]
 #[tokio::test]
 async fn tracer_emits_exec_event(
-  #[allow(unused)] #[case] seccomp_bpf: SeccompBpf,
+  #[allow(unused)]
+  #[case]
+  seccomp_bpf: SeccompBpf,
   #[with(Default::default(), seccomp_bpf)] tracer: TracerFixture,
   true_executable: PathBuf,
 ) {

--- a/src/tui/hit_manager.rs
+++ b/src/tui/hit_manager.rs
@@ -502,7 +502,6 @@ impl HitManager {
           "syscall-exit(right after exec)".cyan().bold(),
           ". ".into(),
         ]),
-        #[cfg(feature = "seccomp-bpf")]
         Line::default().spans(vec![
           "By default, tracexec uses seccomp-bpf to speed up ptrace operations so that there is minimal overhead \
           when running programs inside tracexec. ".into(),


### PR DESCRIPTION
Initially I thought providing this feature gate should make things smoother when porting to other unix systems.

But that didn't happen and it becomes a maintainance burden. Remove it.