### PR TITLE
tui: improve responsiveness in following mode

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -113,12 +113,9 @@ impl Tui {
         let crossterm_event = reader.next().fuse();
         let tracer_event = tracer_rx.recv();
         tokio::select! {
+          biased;
           () = _cancellation_token.cancelled() => {
-              break;
-          }
-          Some(tracer_event) = tracer_event => {
-            trace!("TUI event: tracer message!");
-            event_tx.send(Event::Tracer(tracer_event)).unwrap();
+            break;
           }
           Some(event) = crossterm_event => {
             #[cfg(debug_assertions)]
@@ -145,6 +142,10 @@ impl Tui {
               }
             }
           },
+          Some(tracer_event) = tracer_event => {
+            trace!("TUI event: tracer message!");
+            event_tx.send(Event::Tracer(tracer_event)).unwrap();
+          }
           _ = render_delay => {
             // log::trace!("TUI event: Render!");
             event_tx.send(Event::Render).unwrap();


### PR DESCRIPTION
Previously, when under following mode, we scroll the list to the bottom whenever a new event becomes available.
That ensures at every render, the event list is scrolled to bottom. But it hurts responsiveness because of the computational complexity incurred. This is especially relevant when tracing a full kernel build.

This PR improves responsiveness by opportunistically scroll the list to bottom if we have reached an 100ms interval.

Additionally, use biased select to favor user input over tracer output.