### PR TITLE
Implement and default to use blocking mode for ptrace tracer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,6 +1993,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
+name = "snafu"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4800ae0e2ebdfaea32ffb9745642acdc378740dcbd74d3fb3cd87572a34810c6"
+dependencies = [
+ "backtrace",
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186f5ba9999528053fb497fdf0dd330efcc69cfe4ad03776c9d704bc54fee10f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2276,8 +2298,8 @@ dependencies = [
  "shell-quote",
  "shell-words",
  "signal-hook",
+ "snafu",
  "strum 0.27.1",
- "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,6 @@ arboard = { version = "3.3.2", default-features = false, features = [
     "wayland-data-control",
 ] }
 tui-popup = "0.6.0"
-thiserror = "2"
 tui-scrollview = "0.5.0"
 bitflags = "2.5.0"
 tui-prompts = "0.5.0"
@@ -84,6 +83,7 @@ indexset = "0.12"
 chrono = "0.4.40"
 nutype = { version = "0.6.1", features = ["serde"] }
 humantime = "2.2.0"
+snafu = { version = "0.8.8", features = ["rust_1_81", "backtrace"] }
 # tui-prompts = { version = "0.3.11", path = "../../contrib/tui-prompts" }
 # tui-popup = { version = "0.3.0", path = "../../contrib/tui-popup" }
 

--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ Options:
           Set the format of inline timestamp. See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for available options.
       --seccomp-bpf <SECCOMP_BPF>
           Controls whether to enable seccomp-bpf optimization, which greatly improves performance [default: auto] [possible values: auto, on, off]
-      --tracer-delay <TRACER_DELAY>
-          Delay between polling, in microseconds. The default is 500 when seccomp-bpf is enabled, otherwise 1.
+      --polling-interval <POLLING_INTERVAL>
+          Polling interval, in microseconds. -1(default) disables polling.
       --show-all-events
           Set the default filter to show all events. This option can be used in combination with --filter-exclude to exclude some unwanted events.
       --filter <FILTER>
@@ -294,8 +294,8 @@ Options:
           Set the format of inline timestamp. See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for available options.
       --seccomp-bpf <SECCOMP_BPF>
           Controls whether to enable seccomp-bpf optimization, which greatly improves performance [default: auto] [possible values: auto, on, off]
-      --tracer-delay <TRACER_DELAY>
-          Delay between polling, in microseconds. The default is 500 when seccomp-bpf is enabled, otherwise 1.
+      --polling-interval <POLLING_INTERVAL>
+          Polling interval, in microseconds. -1(default) disables polling.
       --show-all-events
           Set the default filter to show all events. This option can be used in combination with --filter-exclude to exclude some unwanted events.
       --filter <FILTER>
@@ -344,8 +344,8 @@ Options:
           Set the format of inline timestamp. See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for available options.
       --seccomp-bpf <SECCOMP_BPF>
           Controls whether to enable seccomp-bpf optimization, which greatly improves performance [default: auto] [possible values: auto, on, off]
-      --tracer-delay <TRACER_DELAY>
-          Delay between polling, in microseconds. The default is 500 when seccomp-bpf is enabled, otherwise 1.
+      --polling-interval <POLLING_INTERVAL>
+          Polling interval, in microseconds. -1(default) disables polling.
   -F, --format <FORMAT>
           the format for exported exec events [possible values: json-stream, json]
   -p, --pretty

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -4,7 +4,6 @@ use clap::{Args, ValueEnum};
 use color_eyre::eyre::bail;
 use enumflags2::BitFlags;
 use snafu::{ResultExt, Snafu};
-use tracing_subscriber::field::display;
 
 use crate::{
   cli::config::{ColorLevel, EnvDisplay, FileDescriptorDisplay},
@@ -28,9 +27,9 @@ pub struct PtraceArgs {
   pub seccomp_bpf: SeccompBpf,
   #[clap(
     long,
-    help = "Delay between polling, in microseconds. The default is 500 when seccomp-bpf is enabled, otherwise 1."
+    help = "Polling interval, in microseconds. -1(default) disables polling."
   )]
-  pub tracer_delay: Option<u64>,
+  pub polling_interval: Option<i64>,
 }
 
 #[derive(Args, Debug, Default, Clone)]

--- a/src/event.rs
+++ b/src/event.rs
@@ -180,7 +180,7 @@ impl FilterableTracerEventDetails {
     self,
     tx: &mpsc::UnboundedSender<TracerMessage>,
     filter: BitFlags<TracerEventDetailsKind>,
-  ) -> color_eyre::Result<()> {
+  ) -> Result<(), mpsc::error::SendError<TracerMessage>> {
     if let Some(evt) = self.filter_and_take(filter) {
       tx.send(TracerMessage::from(TracerEvent::from(evt)))?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,13 @@ async fn main() -> color_eyre::Result<()> {
         .baseline(Arc::new(baseline))
         .filter(tracer_event_args.filter()?)
         .seccomp_bpf(ptrace_args.seccomp_bpf)
-        .ptrace_polling_delay(ptrace_args.tracer_delay)
+        .ptrace_blocking(ptrace_args.polling_interval.is_none_or(|v| v < 0))
+        .ptrace_polling_delay(
+          ptrace_args
+            .polling_interval
+            .filter(|&v| v > 0)
+            .map(|v| v as u64),
+        )
         .printer_from_cli(&tracing_args)
         .build_ptrace()?;
       let tracer = Arc::new(tracer);
@@ -211,7 +217,13 @@ async fn main() -> color_eyre::Result<()> {
         .baseline(baseline.clone())
         .filter(tracer_event_args.filter()?)
         .seccomp_bpf(ptrace_args.seccomp_bpf)
-        .ptrace_polling_delay(ptrace_args.tracer_delay)
+        .ptrace_blocking(ptrace_args.polling_interval.is_none_or(|v| v < 0))
+        .ptrace_polling_delay(
+          ptrace_args
+            .polling_interval
+            .filter(|&v| v > 0)
+            .map(|v| v as u64),
+        )
         .printer_from_cli(&tracing_args)
         .build_ptrace()?;
       let tracer = Arc::new(tracer);
@@ -276,7 +288,13 @@ async fn main() -> color_eyre::Result<()> {
         .baseline(Arc::new(baseline.clone()))
         .filter(TracerEventArgs::all().filter()?)
         .seccomp_bpf(ptrace_args.seccomp_bpf)
-        .ptrace_polling_delay(ptrace_args.tracer_delay)
+        .ptrace_blocking(ptrace_args.polling_interval.is_none_or(|v| v < 0))
+        .ptrace_polling_delay(
+          ptrace_args
+            .polling_interval
+            .filter(|&v| v > 0)
+            .map(|v| v as u64),
+        )
         .printer_from_cli(&tracing_args)
         .build_ptrace()?;
       let tracer = Arc::new(tracer);


### PR DESCRIPTION
Previously we used async and polling in tracer thread to handle waitpid events and requests.
Due to the wasteful nature of polling, we waste cycles and suffer from longer delay,
which is significant when exec events are occurring at high speed.

There was a parameter `--tracer-delay` for fine-tuning polling interval. That name is awkward and got renamed to `--polling-interval` in this PR.

This PR replaces the default async + polling implementation with a blocking implementation,
which significantly improves performance for exec heavy loads.
This is the right path towards turning tracexec into a build system profiler (#96).

However, since waitpid would block and we may need to handle detach/resume requests,
we use pthread_kill(SIGUSR1) to specifically notify the tracer thread (without SA_RESTART) to stop
restarting interrupted `waitpid` family syscalls so that we could have a chance to handle pending requests.