### PR TITLE
feat(tui): copy command line with full env

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -81,6 +81,7 @@ impl Action {
 pub enum CopyTarget {
   Line,
   Commandline(SupportedShell),
+  CommandlineWithFullEnv(SupportedShell),
   CommandlineWithStdio(SupportedShell),
   CommandlineWithFds(SupportedShell),
   Env,

--- a/src/bpf/tracer.rs
+++ b/src/bpf/tracer.rs
@@ -115,7 +115,7 @@ impl EbpfTracer {
       let should_exit = should_exit.clone();
       move |data| {
         assert!(
-          data.as_ptr() as usize % 8 == 0,
+          (data.as_ptr() as usize).is_multiple_of(8),
           "data is not 8 byte aligned!"
         );
         assert!(

--- a/src/tui/copy_popup.rs
+++ b/src/tui/copy_popup.rs
@@ -33,6 +33,7 @@ pub struct CopyPopupState {
 static KEY_MAP: LazyLock<BTreeMap<char, (&'static str, &'static str)>> = LazyLock::new(|| {
   [
     ('c', ("(C)ommand line", "Cmdline")),
+    ('o', ("C(o)mmand line with full env", "Cmdline with full env")),
     ('s', ("Command line with (S)tdio", "Cmdline with stdio")),
     (
       'f',
@@ -82,6 +83,7 @@ impl CopyPopupState {
     let key = self.available_targets[id];
     match key {
       'c' => CopyTarget::Commandline(Bash),
+      'o' => CopyTarget::CommandlineWithFullEnv(Bash),
       's' => CopyTarget::CommandlineWithStdio(Bash),
       'f' => CopyTarget::CommandlineWithFds(Bash),
       'e' => CopyTarget::Env,

--- a/src/tui/event_list/ui.rs
+++ b/src/tui/event_list/ui.rs
@@ -36,6 +36,7 @@ impl Event {
       self.status,
       true,
       extra_prefix,
+      false,
     )
   }
 }


### PR DESCRIPTION
This PR add another choice for the copy dialog, "Commandline with full env".

This option copies the command line with all the environment variables instead of a diff compared to the base environment.

`env -i` is used to implement that, which starts with an empty environment instead of inheriting.

Since we don't render it anywhere in the TUI now, it is not styled yet.