### PR TITLE
fix(tui): correctly show parent cmdline in details

### DIFF
--- a/src/tui/details_popup.rs
+++ b/src/tui/details_popup.rs
@@ -178,9 +178,13 @@ impl DetailsPopupState {
         let p = inner.borrow();
         details.push((
           label,
-          event
-            .details
-            .to_tui_line(&list.baseline, true, &modifier_args, rt_modifier, None),
+          p.details.to_tui_line(
+            &list.baseline,
+            true,
+            &modifier_args,
+            rt_modifier,
+            None,
+          ),
         ));
         Some(p.id)
       } else {


### PR DESCRIPTION
Previously we incorrectly showed the process itself's cmdline in TUI details. This PR fixes it.