### PR TITLE
refactor: clean up outdated/done todos

### DIFF
--- a/src/bpf/tracer.rs
+++ b/src/bpf/tracer.rs
@@ -556,8 +556,6 @@ impl EbpfTracer {
   }
 }
 
-// TODO: we should start polling the ringbuffer before program load
-
 pub struct RunningEbpfTracer<'obj> {
   rb: RingBuffer<'obj>,
   pub should_exit: Arc<AtomicBool>,

--- a/src/event.rs
+++ b/src/event.rs
@@ -87,7 +87,6 @@ impl From<TracerEventDetails> for TracerEvent {
   fn from(details: TracerEventDetails) -> Self {
     Self {
       details,
-      // TODO: Maybe we can use a weaker ordering here
       id: Self::allocate_id(),
     }
   }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -238,7 +238,6 @@ impl ListPrinter {
     };
     for (k, v) in env.iter() {
       write_separator(out)?;
-      // TODO: Maybe stylize error
       write!(out, "{k}={v}")?;
     }
     self.end(out)
@@ -515,8 +514,6 @@ impl Printer {
         Ok(envp) => {
           match self.args.trace_env {
             EnvPrintFormat::Diff => {
-              // TODO: make it faster
-              //       This is mostly a proof of concept
               write!(out, " {} ", "with".purple())?;
               list_printer.begin(out)?;
               let env = env.clone();
@@ -759,7 +756,6 @@ impl Printer {
             }
             write!(out, " {}", exec_data.filename.bash_escaped())?;
             for arg in argv.iter().skip(1) {
-              // TODO: don't escape err msg
               write!(out, " {}", arg.bash_escaped())?;
             }
           }

--- a/src/ptrace/tracer/test.rs
+++ b/src/ptrace/tracer/test.rs
@@ -147,7 +147,6 @@ async fn tracer_emits_exec_event(
   #[with(Default::default(), seccomp_bpf)] tracer: TracerFixture,
   true_executable: PathBuf,
 ) {
-  // TODO: don't assume FHS
   let (tracer, rx, req_rx) = tracer;
   let true_executable = true_executable.to_string_lossy().to_string();
   let events = run_exe_and_collect_msgs(tracer, rx, req_rx, vec![true_executable.clone()]).await;

--- a/src/tui/event_list.rs
+++ b/src/tui/event_list.rs
@@ -213,7 +213,6 @@ impl EventList {
     self.window
   }
 
-  // TODO: this is ugly due to borrow checking.
   pub fn window<'a, T>(items: (&'a [T], &'a [T]), window: (usize, usize)) -> (&'a [T], &'a [T]) {
     let end = window.1.min(items.0.len() + items.1.len());
     let separation = items.0.len();


### PR DESCRIPTION
This PR cleans up some todos in the code that are either done or outdated.