### PR TITLE
Ignore clangd related temporary files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.bpf.o
 # Clangd
 .cache
+compile_commands.json


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git ignore configuration to refine build artifact tracking.

---

**Note:** This release contains no user-facing changes. Updates were made to internal development configuration only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->