### PR TITLE
bpf!: implement feature and quirk detection at prog load time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,8 +137,6 @@ ebpf = ["dep:tracexec-backend-ebpf"]
 # Either cargo doesn't rebuild and run build.rs on feature flag change,
 # or some logic is wrong in build.rs
 ebpf-debug = ["ebpf", "tracexec-backend-ebpf/ebpf-debug"]
-# Use BPF bits iterator instead of our implementation, requires Linux 6.11
-ebpf-use-iter-bits = ["ebpf", "tracexec-backend-ebpf/ebpf-use-iter-bits"]
 static = ["tracexec-backend-ebpf?/static"]
 vendored = ["tracexec-backend-ebpf?/vendored"]
 vendored-libbpf = ["tracexec-backend-ebpf?/vendored-libbpf"]

--- a/crates/tracexec-backend-ebpf/Cargo.toml
+++ b/crates/tracexec-backend-ebpf/Cargo.toml
@@ -16,8 +16,6 @@ workspace = true
 [features]
 default = ["vendored-libbpf"]
 ebpf-debug = []
-# Use BPF bits iterator instead of our implementation, requires Linux 6.11
-ebpf-use-iter-bits = []
 static = ["libbpf-sys/static"]
 vendored = ["libbpf-sys/vendored", "vendored-libbpf"]
 vendored-libbpf = ["libbpf-sys/vendored-libbpf", "libbpf-cargo/default"]

--- a/crates/tracexec-backend-ebpf/build.rs
+++ b/crates/tracexec-backend-ebpf/build.rs
@@ -38,9 +38,6 @@ fn main() {
   if cfg!(any(feature = "ebpf-debug", debug_assertions)) {
     clang_args.push(OsStr::new("-DEBPF_DEBUG"));
   }
-  if cfg!(feature = "ebpf-use-iter-bits") {
-    clang_args.push(OsStr::new("-DUSE_ITER_BITS"));
-  }
   let mut builder = SkeletonBuilder::new();
   builder.source(bpf_src).clang_args(clang_args);
   if let Some(path) = std::env::var_os("CLANG") {

--- a/crates/tracexec-backend-ebpf/src/bpf/common.h
+++ b/crates/tracexec-backend-ebpf/src/bpf/common.h
@@ -68,6 +68,7 @@ extern void bpf_rcu_read_lock(void) __ksym;
 extern void bpf_rcu_read_unlock(void) __ksym;
 
 #define MIN_KERNEL_VERSION_FOR_RCU_KFUNC KERNEL_VERSION(6, 2, 0)
+#define MIN_KERNEL_VERSION_FOR_ITER_BITS KERNEL_VERSION(6, 11, 0)
 
 int __always_inline rcu_read_lock() {
   if (LINUX_KERNEL_VERSION >= MIN_KERNEL_VERSION_FOR_RCU_KFUNC) {

--- a/crates/tracexec-backend-ebpf/src/bpf/tracexec_system.bpf.c
+++ b/crates/tracexec-backend-ebpf/src/bpf/tracexec_system.bpf.c
@@ -123,12 +123,12 @@ static int add_tgid_to_closure(pid_t tgid);
 static int read_send_path(const struct path *path,
                           struct tracexec_event_header *base_header,
                           s32 path_id, struct fd_event *fd_event);
-#ifdef USE_ITER_BITS
+
+// iter bits implementation for iterating over fdset
 static int iter_fdset_chunk(u32 chunk, void *data);
-#else
+// old hand-written implementation for iterating over fdset
 static int read_fds_impl(u32 index, struct fdset_reader_context *ctx);
 static int read_fdset_word(u32 index, struct fdset_word_reader_context *ctx);
-#endif
 
 #ifdef EBPF_DEBUG
 #define debug(...) bpf_printk("tracexec_system: " __VA_ARGS__);
@@ -709,20 +709,21 @@ static int read_fds(struct exec_event *event) {
   // https://github.com/torvalds/linux/blob/5189dafa4cf950e675f02ee04b577dfbbad0d9b1/fs/file.c#L279-L291
   ctx.size = max_fds / BITS_PER_LONG;
   ctx.size = min(ctx.size, FDSET_SIZE_MAX_IN_LONG);
-#ifdef USE_ITER_BITS
-  // For USE_ITER_BITS, the unit of size is bit (not the number of words)
-  ctx.size *= BITS_PER_LONG;
-  u32 chunks = (ctx.size + BPF_BITS_ITER_MAX_BITS - 1) / BPF_BITS_ITER_MAX_BITS;
-  ret = bpf_loop(chunks, iter_fdset_chunk, &ctx, 0);
-  
+  if (LINUX_KERNEL_VERSION >= MIN_KERNEL_VERSION_FOR_ITER_BITS) {
+    // When using iter_bits, the unit of size is bit (not the number of words)
+    ctx.size *= BITS_PER_LONG;
+    u32 chunks = (ctx.size + BPF_BITS_ITER_MAX_BITS - 1) / BPF_BITS_ITER_MAX_BITS;
+    ret = bpf_loop(chunks, iter_fdset_chunk, &ctx, 0);
+  } else {
+    ret = bpf_loop(ctx.size, read_fds_impl, &ctx, 0);
+  }
+
   if (ret < 0) {
     debug("Failed to iter over all fds: %d!", ret);
     ctx.event->header.flags |= LOOP_FAIL;
     return ret;
   }
-#else
-  bpf_loop(ctx.size, read_fds_impl, &ctx, 0);
-#endif
+
   return 0;
 probe_failure_locked_rcu:
   rcu_read_unlock();
@@ -731,7 +732,7 @@ probe_failure:
   return -EFAULT;
 }
 
-#ifdef USE_ITER_BITS
+// BEGIN iter bits implementation for iterating the fdset
 
 
 static int iter_fdset_chunk(u32 chunk, void *data)
@@ -779,7 +780,9 @@ static int iter_fdset_chunk(u32 chunk, void *data)
 }
 
 
-#else
+// END iter bits implementation for iterating the fdset
+
+// BEGIN hand-written implementation for iterating the fdset
 
 // Ref:
 // https://elixir.bootlin.com/linux/v6.10.3/source/include/asm-generic/bitops/__ffs.h#L45
@@ -879,7 +882,7 @@ static int read_fdset_word(u32 index, struct fdset_word_reader_context *ctx) {
   return 0;
 }
 
-#endif
+// END hand-written implementation for iterating the fdset
 
 // Gather information about a single fd and send it back to userspace
 static int _read_fd(unsigned int fd_num, struct file **fd_array,

--- a/nix/tracexec.nix
+++ b/nix/tracexec.nix
@@ -51,7 +51,6 @@ localFlake:
         in
         {
           tracexec = builder { cargoExtraArgs = "--locked"; };
-          tracexec_use_iter_bits = builder { cargoExtraArgs = "--locked -F ebpf-use-iter-bits"; };
         };
     };
 }

--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -54,7 +54,7 @@ localFlake:
               tag = "6.19.6";
               version = "6.19.6";
               source = "mirror";
-              test_exe = "tracexec_use_iter_bits";
+              test_exe = "tracexec";
               sha256 = "sha256-TZ8/9zIU9owBlO8C25ykt7pxMlOsEEVEHU6fNSvCLhQ=";
             }
             {
@@ -62,7 +62,7 @@ localFlake:
               tag = "v7.0-rc2";
               version = "7.0.0-rc2";
               source = "linus";
-              test_exe = "tracexec_use_iter_bits";
+              test_exe = "tracexec";
               sha256 = "sha256-BlKlJdEYvwDN6iWJfuOvd1gcm6lN6McJ/vmMwOmzHdc=";
             }
           ];
@@ -168,9 +168,6 @@ localFlake:
             case "$1" in
               tracexec)
                 package="${self'.packages.tracexec}"
-                ;;
-              tracexec_use_iter_bits)
-                package="${self'.packages.tracexec_use_iter_bits}"
                 ;;
               *)
                 echo "Unrecognized executable!"


### PR DESCRIPTION
Previously, we do not do kernel feature/quirk detection at all.
We only have a compile-time `ebpf-no-rcu-kfuncs` feature for compatibility with Linux <= 6.2.

Recently, I added a new compile-time `ebpf-use-iter-bits` feature which is a compatibility fix for Linux >= 6.19.4.
It will start to become unmaintainable if we continue to add compile-time ebpf feature gates this way.

So let's implement kernel  feature and quirk detection at prog load time based on kernel versions.
Unfortunately this means that we are doing the detection solely based on kernel versions
that might not be reliable at all since some distributions backport new features to old kernels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced eBPF backend compatibility by implementing runtime kernel version detection, enabling better support across different Linux kernel versions without requiring build-time configuration.

* **Chores**
  * Simplified build configuration by removing the alternative build variant and related options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->