### PR TITLE
ci: switch cache backend to buildjet for nix pipeline

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -61,6 +61,7 @@ jobs:
           purge-last-accessed: 0
           # except any version with the key that is the same as the `primary-key`
           purge-primary-key: never
+          backend: buildjet
       # Build and test tracexec
       # Also builds kernels
       - run: nix build


### PR DESCRIPTION
We are hitting 10GB cache limit for GitHub Actions.

Buildjet offers another 20GB for free.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build pipeline configuration to optimize caching performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->