### PR TITLE
bpf: switch ukci to use self-hosted attic cache

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -36,7 +36,7 @@ jobs:
           
       - name: Setup Attic cache (Writable)
         uses: ryanccn/attic-action@v0.4.1
-        if: github.event.pull_request.head.repo.fork == false
+        if: github.event.pull_request.head.repo.fork != true
         with:
           endpoint: https://nix.kxxt.dev
           cache: tracexec


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Replaced CI caching with a new Attic-based external cache service and updated cache configuration.
  * Introduced writable cache for non-fork PRs and read-only cache behavior for forked PRs.
  * Cache tokens now come from CI secrets; HTTP/2 usage disabled for the cache action.
  * Removed legacy cache inputs; build and test steps remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->