### PR TITLE
bpf: avoid embedding object into skel to speed up compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1419,9 +1419,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libbpf-cargo"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df559c3961ae45e06aaff479036261375dbf0226541aa4155e60aa277fb37d6"
+checksum = "fdd59674b82a31cb53e512cee97e3d5143737b40feda35f89b5b7f5c439e51e8"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -1438,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "libbpf-rs"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c7c1017b506e5cbc007f65abb78b21bd5957dff9358882427ddbf634ba415b"
+checksum = "a6af29f679fd713ba4466b0296436268f573f6c5a8ef2f316d237eb3019c3c6f"
 dependencies = [
  "bitflags 2.11.0",
  "libbpf-sys",

--- a/crates/tracexec-backend-ebpf/Cargo.toml
+++ b/crates/tracexec-backend-ebpf/Cargo.toml
@@ -31,10 +31,10 @@ chrono = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 bytemuck = "1.24.0"
-libbpf-rs = { version = "0.26", default-features = false }
+libbpf-rs = { version = "0.26.1", default-features = false }
 # libbpf-sys exists here because we want to control its features
 libbpf-sys = { version = "1", default-features = false }
 
 
 [build-dependencies]
-libbpf-cargo = { version = "0.26", default-features = false }
+libbpf-cargo = { version = "0.26.1", default-features = false }

--- a/crates/tracexec-backend-ebpf/build.rs
+++ b/crates/tracexec-backend-ebpf/build.rs
@@ -14,8 +14,8 @@ fn main() {
   let manifest_dir =
     PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"));
   let bpf_src = manifest_dir.join(BPF_SRC);
-  let skel_out =
-    PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set")).join("tracexec_system.skel.rs");
+  let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+  let skel_out = out_dir.join("tracexec_system.skel.rs");
   let arch = env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH not set");
   let arch_define = OsStr::new(match arch.as_str() {
     "x86_64" => "TRACEXEC_TARGET_X86_64",
@@ -39,6 +39,9 @@ fn main() {
     clang_args.push(OsStr::new("-DEBPF_DEBUG"));
   }
   let mut builder = SkeletonBuilder::new();
+  builder.reference_obj(true);
+  // TODO: drop the following line when https://github.com/libbpf/libbpf-rs/pull/1354 lands
+  builder.obj(out_dir.join("tracexec_system.o"));
   builder.source(bpf_src).clang_args(clang_args);
   if let Some(path) = std::env::var_os("CLANG") {
     builder.clang(path);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated eBPF backend library dependencies to version 0.26.1.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->