### PR TITLE
ci: update ukci flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1754269165,
-        "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
+        "lastModified": 1772560058,
+        "narHash": "sha256-NuVKdMBJldwUXgghYpzIWJdfeB7ccsu1CC7B+NfSoZ8=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "444e81206df3f7d92780680e45858e31d2f07a08",
+        "rev": "db590d9286ed5ce22017541e36132eab4e8b3045",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1754487366,
-        "narHash": "sha256-pHYj8gUBapuUzKV/kN/tR3Zvqc7o6gdFB9XKXIp1SQ8=",
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "af66ad14b28a127c5c0f3bbb298218fc63528a18",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
         "type": "github"
       },
       "original": {
@@ -35,11 +35,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1754393734,
-        "narHash": "sha256-fbnmAwTQkuXHKBlcL5Nq1sMAzd3GFqCOQgEQw6Hy0Ak=",
+        "lastModified": 1772736753,
+        "narHash": "sha256-au/m3+EuBLoSzWUCb64a/MZq6QUtOV8oC0D9tY2scPQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a683adc19ff5228af548c6539dbc3440509bfed3",
+        "rev": "917fec990948658ef1ccd07cef2a1ef060786846",
         "type": "github"
       },
       "original": {
@@ -51,11 +51,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1753579242,
-        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
         "type": "github"
       },
       "original": {

--- a/nix/kernel-build.nix
+++ b/nix/kernel-build.nix
@@ -35,15 +35,15 @@
    , version
    , # Install the GDB scripts
      kernelPatches ? [ ]
+   , extraMakeFlags
    , nixpkgs
    , # Nixpkgs source
    }:
 let
   kernel =
-    # todo: migrate to  ../os-specific/linux/kernel/build.nix { };
-    ((callPackage "${nixpkgs}/pkgs/os-specific/linux/kernel/manual-config.nix" { })
+    ((callPackage "${nixpkgs}/pkgs/os-specific/linux/kernel/build.nix" { })
       {
-        inherit src modDirVersion version kernelPatches configfile;
+        inherit src modDirVersion version kernelPatches configfile extraMakeFlags;
         inherit lib stdenv;
 
         # Because allowedImportFromDerivation is not enabled,
@@ -61,49 +61,43 @@ let
       dontStrip = true;
 
       postInstall = ''
-        mkdir -p $dev
-        cp vmlinux $dev/
-        if [ -z "''${dontStrip-}" ]; then
-          installFlagsArray+=("INSTALL_MOD_STRIP=1")
-        fi
-        make modules_install $makeFlags "''${makeFlagsArray[@]}" \
-          $installFlags "''${installFlagsArray[@]}"
-        if [ -L "$out/lib/modules/${modDirVersion}/build" ]; then
-          unlink $out/lib/modules/${modDirVersion}/build
-        fi
-        if [ -L "$out/lib/modules/${modDirVersion}/source" ]; then
-          unlink $out/lib/modules/${modDirVersion}/source
-        fi
+          mkdir -p $dev
+          cp vmlinux $dev/
 
-        mkdir -p $dev/lib/modules/${modDirVersion}/{build,source}
+          mkdir -p $dev/lib/modules/${modDirVersion}/{build,source}
+          cp -rL $buildRoot/scripts $dev/lib/modules/${modDirVersion}/build/
+          cp -L $buildRoot/vmlinux-gdb.py $dev/lib/modules/${modDirVersion}/build/scripts/gdb/
+          ln -sfn $dev/lib/modules/${modDirVersion}/build/scripts/gdb/vmlinux-gdb.py $dev/lib/modules/${modDirVersion}/build/vmlinux-gdb.py
 
-        # To save space, exclude a bunch of unneeded stuff when copying.
-        (cd .. && rsync --archive --prune-empty-dirs \
-            --exclude='/build/' \
-            * $dev/lib/modules/${modDirVersion}/source/)
-
-        cd $dev/lib/modules/${modDirVersion}/source
-
-        cp $buildRoot/{.config,Module.symvers} $dev/lib/modules/${modDirVersion}/build
-
-        make modules_prepare $makeFlags "''${makeFlagsArray[@]}" O=$dev/lib/modules/${modDirVersion}/build
-
-        # For reproducibility, removes accidental leftovers from a `cc1` call
-        # from a `try-run` call from the Makefile
-        rm -f $dev/lib/modules/${modDirVersion}/build/.[0-9]*.d
-
-        # Keep some extra files on some arches (powerpc, aarch64)
-        for f in arch/powerpc/lib/crtsavres.o arch/arm64/kernel/ftrace-mod.o; do
-          if [ -f "$buildRoot/$f" ]; then
-            cp $buildRoot/$f $dev/lib/modules/${modDirVersion}/build/$f
+          if [ -z "''${dontStrip-}" ]; then
+            installFlags+=("INSTALL_MOD_STRIP=1")
           fi
-        done
+          make modules_install "''${makeFlags[@]}" "''${installFlags[@]}"
+          unlink $modules/lib/modules/${modDirVersion}/build
 
-        # Not doing the nix default of removing files from the source tree.
-        # This is because the source tree is necessary for debugging with GDB.
+          # To save space, exclude a bunch of unneeded stuff when copying.
+          (cd .. && rsync --archive --prune-empty-dirs \
+              --exclude='/build/' \
+              * $dev/lib/modules/${modDirVersion}/source/)
 
-        # Remove reference to kmod
-        sed -i Makefile -e 's|= ${buildPackages.kmod}/bin/depmod|= depmod|'
+          cd $dev/lib/modules/${modDirVersion}/source
+          cp $buildRoot/{.config,Module.symvers} $dev/lib/modules/${modDirVersion}/build
+
+          make modules_prepare "''${makeFlags[@]}" O=$dev/lib/modules/${modDirVersion}/build
+
+          # For reproducibility, removes accidental leftovers from a `cc1` call
+          # from a `try-run` call from the Makefile
+          rm -f $dev/lib/modules/${modDirVersion}/build/.[0-9]*.d
+
+          # Keep some extra files on some arches (powerpc, aarch64)
+          for f in arch/powerpc/lib/crtsavres.o arch/arm64/kernel/ftrace-mod.o; do
+            if [ -f "$buildRoot/$f" ]; then
+              cp $buildRoot/$f $dev/lib/modules/${modDirVersion}/build/$f
+            fi
+          done
+
+          # Not doing the nix default of removing files from the source tree.
+          # This is because the source tree is necessary for debugging with GDB.
       '';
     });
 

--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -32,6 +32,7 @@ localFlake:
                   patch = ./0001-Replace-scripts-pahole-flags.sh-with-the-one-in-5.15.patch;
                 }
               ];
+              extraMakeFlags = [];
             }
             {
               name = "6.1lts";
@@ -40,6 +41,7 @@ localFlake:
               test_exe = "tracexec";
               sha256 = "sha256-WoFxhPG+kBt1x+CvwCN2vDrFFiTgPsb3uKX505XSLvQ=";
               kernelPatches = [];
+              extraMakeFlags = [];
             }
             {
               name = "6.6lts";
@@ -48,6 +50,7 @@ localFlake:
               test_exe = "tracexec";
               sha256 = "sha256-ZpYzu4SAAh8Vw4iD+y9v4gh8yLaaWC8m9rfUrms0jkg=";
               kernelPatches = [];
+              extraMakeFlags = [];
             }
             {
               name = "6.12lts";
@@ -56,6 +59,7 @@ localFlake:
               test_exe = "tracexec";
               sha256 = "sha256-Bu55J1Vv8aqIEMSCZQGw/bFp69wYBkS4gs98FDrBwXc=";
               kernelPatches = [];
+              extraMakeFlags = [];
             }
             {
               name = "6.18lts";
@@ -65,6 +69,7 @@ localFlake:
               test_exe = "tracexec";
               sha256 = "sha256-TyHAH00EwdGz7XlBU/iQCALJJJe+YgsHxIaVMPLSjuM=";
               kernelPatches = [];
+              extraMakeFlags = [];
             }
             {
               name = "6.19";
@@ -74,6 +79,7 @@ localFlake:
               test_exe = "tracexec";
               sha256 = "sha256-TZ8/9zIU9owBlO8C25ykt7pxMlOsEEVEHU6fNSvCLhQ=";
               kernelPatches = [];
+              extraMakeFlags = [];
             }
             {
               name = "7.0";
@@ -83,11 +89,12 @@ localFlake:
               test_exe = "tracexec";
               sha256 = "sha256-BlKlJdEYvwDN6iWJfuOvd1gcm6lN6McJ/vmMwOmzHdc=";
               kernelPatches = [];
+              extraMakeFlags = [];
             }
           ];
           nixpkgs = localFlake.nixpkgs;
           configureKernel = pkgs.callPackage ./kernel-configure.nix { };
-          buildKernel = pkgs.callPackage ./kernel-build.nix { };
+          buildKernel = pkgs.callPackage ./kernel-build.nix { stdenv = pkgs.gcc14Stdenv; };
           kernelNixConfig = source: pkgs.callPackage ./kernel-source.nix source;
           kernels = map (
             source:
@@ -109,7 +116,7 @@ localFlake:
                   modDirVersion
                   version
                   ;
-                inherit (source) kernelPatches;
+                inherit (source) kernelPatches extraMakeFlags;
                 inherit configfile nixpkgs;
               };
               buildInitramfs = pkgs.callPackage ./initramfs.nix { };


### PR DESCRIPTION
This PR updates flake.lock to use latest nixpkgs and fixes the incompatibilities with latest nixpkgs.

Some code taken from https://github.com/jordanisaacs/kernel-development-flake/blob/main/build/kernel.nix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined kernel build process with reorganized installation workflow for improved efficiency
  * Enhanced kernel module installation and source tree management
  * Improved development environment setup with better debugging tool integration
  * Optimized build flag handling and configuration management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->