### PR TITLE
feat: --elevate for convenient tracer privillege elevation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,6 +3128,7 @@ dependencies = [
  "signal-hook 0.4.3",
  "signal-hook-tokio",
  "strum",
+ "tempfile",
  "tokio",
  "tracexec-backend-ebpf",
  "tracexec-backend-ptrace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,8 @@ tracexec-backend-ebpf = { workspace = true, optional = true }
 assert_cmd = "2.0.14"
 serial_test = { workspace = true }
 predicates = { workspace = true }
+nix = { workspace = true }
+tempfile = { workspace = true }
 
 [features]
 default = ["recommended", "vendored-libbpf"]

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -21,6 +21,7 @@
   - [Export Frontend](./features/collect.md)
     - [Perfetto Trace Export](./features/collect/perfetto.md)
     - [JSON Export](./features/collect/json.md)
+  - [Convenient Privilege Elevation](./features/elevation.md)
   - [Experimental Features](./features/experimental.md)
 - [Tutorials](./tutorials.md)
   - [Debugging a basic build problem](./tutorials/basic-build-problem.md)

--- a/book/features/elevation.md
+++ b/book/features/elevation.md
@@ -1,0 +1,34 @@
+# Convenient Privilege Elevation
+
+When using tracexec with eBPF backend or tracing setuid/setgid binaries with ptrace backend,
+it usually requires running tracexec as root.
+However, using sudo with tracexec is a little tricky because sudo manipulates the environment variables,
+which might not be noticed by the user.
+
+For example, when running `sudo tracexec ebpf log -- make -j$(nproc)`,
+
+- `sudo` resets the environment variables for tracexec and the tracee by retaining
+  a minimal set of basic environment variables and may override some important variables for security reasons (e.g. `PATH`).
+- `sudo` inserts its own environment variables like `SUDO_USER`, `SUDO_UID` and `SUDO_COMMAND`.
+- The tracee `make` is ran as root, which may not be desired.
+
+In many cases, what we want to achieve is to run tracexec with root privilege
+but still run the tracee in the original context as an unprivileged user.
+The following command almost achieves it, with the caveat that `sudo -E` still modifies the environment variables.
+
+```bash
+sudo -E tracexec --user $(whoami) ebpf log -- make -j$(nproc)
+```
+
+Starting at tracexec 0.18.0, we offer a new CLI flag that conveniently runs tracexec as root but
+runs tracee with the original user and environment variables.
+
+For example, the following command runs tracexec as root but runs `make -j$(nproc)` as the original user:
+
+```bash
+tracexec --elevate ebpf log -- make -j$(nproc)
+```
+
+When using this feature, tracexec will internally use `sudo` for privilege elevation.
+So sudo needs to be installed on your system and you may need to authenticate yourself
+to sudo when tracexec executes sudo.

--- a/crates/tracexec-core/Cargo.toml
+++ b/crates/tracexec-core/Cargo.toml
@@ -44,8 +44,8 @@ tokio = { workspace = true }
 clap = { workspace = true }
 crossterm = { workspace = true }
 internment = { version = "0.8.6", default-features = false, features = ["arc", "serde"] }
+tempfile = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
 rusty-fork = { workspace = true }
-tempfile = { workspace = true }

--- a/crates/tracexec-core/src/cli.rs
+++ b/crates/tracexec-core/src/cli.rs
@@ -64,9 +64,48 @@ pub struct Cli {
   #[arg(
     short,
     long,
-    help = "Run as user. This option is only available when running tracexec as root"
+    help = "Run as user. This option is only available when running tracexec as root",
+    conflicts_with = "elevate"
   )]
   pub user: Option<String>,
+  #[arg(
+    long,
+    help = "Re-execute tracexec with privilege elevation (e.g. via sudo). \
+            The original user credentials are saved and the tracee will run as the original user.",
+    conflicts_with = "user"
+  )]
+  pub elevate: bool,
+  #[arg(
+    long,
+    hide = true,
+    conflicts_with = "elevate",
+    help = "Internal: path to a saved environment file from --elevate"
+  )]
+  pub restore_env_file: Option<PathBuf>,
+  #[arg(
+    long,
+    hide = true,
+    conflicts_with = "elevate",
+    requires_all = ["elevated_data_dir", "elevated_data_local_dir"],
+    help = "Internal: original user's config directory from --elevate"
+  )]
+  pub elevated_config_dir: Option<PathBuf>,
+  #[arg(
+    long,
+    hide = true,
+    conflicts_with = "elevate",
+    requires_all = ["elevated_config_dir", "elevated_data_local_dir"],
+    help = "Internal: original user's data directory from --elevate"
+  )]
+  pub elevated_data_dir: Option<PathBuf>,
+  #[arg(
+    long,
+    hide = true,
+    conflicts_with = "elevate",
+    requires_all = ["elevated_config_dir", "elevated_data_dir"],
+    help = "Internal: original user's local data directory from --elevate"
+  )]
+  pub elevated_data_local_dir: Option<PathBuf>,
   #[clap(subcommand)]
   pub cmd: CliCommand,
 }
@@ -386,6 +425,38 @@ mod tests {
   }
 
   #[test]
+  fn test_cli_parse_elevate_tui() {
+    let args = vec!["tracexec", "--elevate", "tui", "-t", "--", "sudo", "ls"];
+    let cli = Cli::parse_from(args);
+    assert!(cli.elevate);
+    assert!(cli.user.is_none());
+    if let CliCommand::Tui { cmd, .. } = cli.cmd {
+      assert_eq!(cmd, vec!["sudo", "ls"]);
+    } else {
+      panic!("Expected Tui command");
+    }
+  }
+
+  #[test]
+  fn test_cli_parse_elevate_log() {
+    let args = vec!["tracexec", "--elevate", "log", "--", "ls"];
+    let cli = Cli::parse_from(args);
+    assert!(cli.elevate);
+    if let CliCommand::Log { cmd, .. } = cli.cmd {
+      assert_eq!(cmd, vec!["ls"]);
+    } else {
+      panic!("Expected Log command");
+    }
+  }
+
+  #[test]
+  fn test_cli_parse_elevate_conflicts_with_user() {
+    let args = vec!["tracexec", "--elevate", "--user", "root", "log", "--", "ls"];
+    let result = Cli::try_parse_from(args);
+    assert!(result.is_err());
+  }
+
+  #[test]
   fn test_cli_parse_tui_theme_file_cli_source() {
     let args = vec![
       "tracexec",
@@ -440,6 +511,11 @@ mod tests {
       profile: None,
       no_profile: false,
       user: None,
+      elevate: false,
+      restore_env_file: None,
+      elevated_config_dir: None,
+      elevated_data_dir: None,
+      elevated_data_local_dir: None,
       cmd: CliCommand::Log {
         cmd: vec!["ls".into()],
         tracing_args: LogModeArgs {
@@ -494,6 +570,11 @@ mod tests {
       profile: None,
       no_profile: false,
       user: None,
+      elevate: false,
+      restore_env_file: None,
+      elevated_config_dir: None,
+      elevated_data_dir: None,
+      elevated_data_local_dir: None,
       cmd: CliCommand::Tui {
         cmd: vec!["bash".into()],
         modifier_args: ModifierArgs::default(),
@@ -553,6 +634,11 @@ mod tests {
       profile: None,
       no_profile: false,
       user: None,
+      elevate: false,
+      restore_env_file: None,
+      elevated_config_dir: None,
+      elevated_data_dir: None,
+      elevated_data_local_dir: None,
       cmd: CliCommand::Collect {
         cmd: vec!["ls".into()],
         modifier_args: ModifierArgs::default(),

--- a/crates/tracexec-core/src/cli/config.rs
+++ b/crates/tracexec-core/src/cli/config.rs
@@ -1,6 +1,10 @@
 use std::{
   io,
-  path::PathBuf,
+  path::{
+    Path,
+    PathBuf,
+  },
+  sync::OnceLock,
 };
 
 use directories::ProjectDirs;
@@ -24,6 +28,60 @@ use crate::{
   cli::keys::TuiKeyBindingsConfig,
   timestamp::TimestampFormat,
 };
+
+/// Wrapper around `ProjectDirs` that supports overriding directories
+/// (e.g. when running elevated via sudo, to use the original user's dirs).
+#[derive(Debug, Clone)]
+pub struct TracexecProjectDirs {
+  config_dir: PathBuf,
+  data_dir: PathBuf,
+  data_local_dir: PathBuf,
+}
+
+impl TracexecProjectDirs {
+  pub fn config_dir(&self) -> &Path {
+    &self.config_dir
+  }
+
+  pub fn data_dir(&self) -> &Path {
+    &self.data_dir
+  }
+
+  pub fn data_local_dir(&self) -> &Path {
+    &self.data_local_dir
+  }
+}
+
+impl From<ProjectDirs> for TracexecProjectDirs {
+  fn from(dirs: ProjectDirs) -> Self {
+    Self {
+      config_dir: dirs.config_dir().to_path_buf(),
+      data_dir: dirs.data_dir().to_path_buf(),
+      data_local_dir: dirs.data_local_dir().to_path_buf(),
+    }
+  }
+}
+
+struct ProjectDirOverrides {
+  config_dir: PathBuf,
+  data_dir: PathBuf,
+  data_local_dir: PathBuf,
+}
+
+static PROJECT_DIR_OVERRIDES: OnceLock<ProjectDirOverrides> = OnceLock::new();
+
+/// Set overrides for the project directories. Must be called before any call to
+/// `project_directory()`. Used by the elevated process to point at the original
+/// user's config/data directories.
+pub fn set_project_dir_overrides(config_dir: PathBuf, data_dir: PathBuf, data_local_dir: PathBuf) {
+  PROJECT_DIR_OVERRIDES
+    .set(ProjectDirOverrides {
+      config_dir,
+      data_dir,
+      data_local_dir,
+    })
+    .ok();
+}
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct Config {
@@ -179,8 +237,16 @@ pub enum ExitHandling {
   Terminate,
 }
 
-pub fn project_directory() -> Option<ProjectDirs> {
-  ProjectDirs::from("dev", "kxxt", "tracexec")
+pub fn project_directory() -> Option<TracexecProjectDirs> {
+  if let Some(overrides) = PROJECT_DIR_OVERRIDES.get() {
+    return Some(TracexecProjectDirs {
+      config_dir: overrides.config_dir.clone(),
+      // On Linux data_dir and data_local_dir are the same for ProjectDirs.
+      data_dir: overrides.data_dir.clone(),
+      data_local_dir: overrides.data_local_dir.clone(),
+    });
+  }
+  ProjectDirs::from("dev", "kxxt", "tracexec").map(TracexecProjectDirs::from)
 }
 
 #[cfg(test)]

--- a/crates/tracexec-core/src/elevate.rs
+++ b/crates/tracexec-core/src/elevate.rs
@@ -1,0 +1,680 @@
+//! Privilege elevation support for tracexec.
+//!
+//! When `--elevate` is used, tracexec captures the current user's credentials
+//! and environment variables, saves them to a secure temporary file, then
+//! re-executes itself with elevated privileges via `sudo`. The elevated process
+//! restores the original environment from the file and passes `--user <username>`
+//! so the tracee runs as the original user.
+//!
+//! ## Security
+//!
+//! The environment file is created with mode 0600 and owned by the current user.
+//! On restore, the file is opened with `O_NOFOLLOW` (rejecting symlinks), its
+//! metadata is checked via `fstat` (avoiding TOCTOU races), and it is unlinked
+//! immediately after reading. Only the original user and root can access it.
+
+use std::{
+  ffi::OsString,
+  fs,
+  io::{
+    Read,
+    Write,
+  },
+  os::unix::{
+    ffi::OsStrExt,
+    fs::OpenOptionsExt,
+  },
+  path::Path,
+  process::Command,
+};
+
+use nix::{
+  fcntl::OFlag,
+  sys::stat::{
+    self,
+    SFlag,
+  },
+  unistd::{
+    Uid,
+    User,
+  },
+};
+
+/// Saved credentials from before privilege elevation.
+#[derive(Debug, Clone)]
+pub struct PreElevationCreds {
+  pub username: String,
+  pub uid: u32,
+  pub gid: u32,
+}
+
+impl PreElevationCreds {
+  /// Capture the current process's real credentials.
+  pub fn capture() -> color_eyre::Result<Self> {
+    let uid = nix::unistd::getuid();
+    let gid = nix::unistd::getgid();
+    let user = User::from_uid(uid)?
+      .ok_or_else(|| color_eyre::eyre::eyre!("Failed to look up current user (uid={uid})"))?;
+    Ok(Self {
+      username: user.name,
+      uid: uid.as_raw(),
+      gid: gid.as_raw(),
+    })
+  }
+}
+
+/// Serialize all current environment variables into a byte buffer.
+///
+/// Uses the null-byte-separated `KEY=VALUE\0` format (same as `/proc/self/environ`).
+fn serialize_env() -> Vec<u8> {
+  let mut buf = Vec::new();
+  for (key, value) in std::env::vars_os() {
+    buf.extend_from_slice(key.as_bytes());
+    buf.push(b'=');
+    buf.extend_from_slice(value.as_bytes());
+    buf.push(0);
+  }
+  buf
+}
+
+/// Deserialize environment variables from null-byte-separated `KEY=VALUE\0` format.
+fn deserialize_env(data: &[u8]) -> Vec<(OsString, OsString)> {
+  use std::os::unix::ffi::OsStringExt;
+  let mut result = Vec::new();
+  for entry in data.split(|&b| b == 0) {
+    if entry.is_empty() {
+      continue;
+    }
+    if let Some(eq_pos) = entry.iter().position(|&b| b == b'=') {
+      let key = OsString::from_vec(entry[..eq_pos].to_vec());
+      let value = OsString::from_vec(entry[eq_pos + 1..].to_vec());
+      result.push((key, value));
+    }
+  }
+  result
+}
+
+/// Save the current environment to a temporary file with secure permissions.
+///
+/// Returns the path to the file. The file is created with mode 0600.
+fn save_env_to_file() -> color_eyre::Result<std::path::PathBuf> {
+  let dir = std::env::temp_dir();
+  let env_data = serialize_env();
+
+  // Create tempfile with a unique path, then write data to it.
+  // tempfile creates with mode 0600 by default on Unix.
+  let mut tmpfile = tempfile::Builder::new()
+    .prefix("tracexec-env-")
+    .tempfile_in(&dir)?;
+  tmpfile.write_all(&env_data)?;
+  tmpfile.flush()?;
+
+  // Persist so the file survives after we exec into sudo.
+  let path = tmpfile.into_temp_path().keep()?;
+  Ok(path)
+}
+
+/// Restore environment variables from a saved env file.
+///
+/// Security checks performed:
+/// - File is opened with `O_NOFOLLOW` to reject symlinks
+/// - `fstat` is used on the open fd to verify:
+///   - File is a regular file
+/// - File is unlinked immediately after reading
+pub fn restore_env_from_file(path: &Path) -> color_eyre::Result<()> {
+  // Open with O_NOFOLLOW to reject symlinks
+  let file = fs::OpenOptions::new()
+    .read(true)
+    .custom_flags(OFlag::O_NOFOLLOW.bits())
+    .open(path)
+    .map_err(|e| color_eyre::eyre::eyre!("Failed to open env file {}: {e}", path.display()))?;
+
+  let fd_stat = stat::fstat(&file)?;
+
+  // Verify it's a regular file
+  let file_type = SFlag::from_bits_truncate(fd_stat.st_mode & SFlag::S_IFMT.bits());
+  if file_type != SFlag::S_IFREG {
+    color_eyre::eyre::bail!(
+      "Env file {} is not a regular file (mode={:#o})",
+      path.display(),
+      fd_stat.st_mode
+    );
+  }
+
+  // Read the file contents
+  let mut data = Vec::new();
+  let mut file = file;
+  file.read_to_end(&mut data)?;
+
+  // Unlink immediately after reading
+  if let Err(e) = fs::remove_file(path) {
+    tracing::warn!("Failed to remove env file {}: {e}", path.display());
+  }
+
+  // Deserialize and restore
+  let saved_env = deserialize_env(&data);
+
+  // SAFETY: restore_env_from_file is called early in main.
+  unsafe {
+    // Clear all current env vars
+    for (key, _) in std::env::vars_os() {
+      std::env::remove_var(&key);
+    }
+
+    // Set the saved env vars
+    for (key, value) in saved_env {
+      std::env::set_var(key, value);
+    }
+  }
+
+  Ok(())
+}
+
+/// Construct the command line for re-execution with elevation.
+///
+/// Transforms `tracexec --elevate [opts] <subcommand> [args] -- <cmd...>`
+/// into
+///
+/// ```bash
+/// sudo tracexec --user <username> --restore-env-file <path> \
+///   --elevated-config-dir <path> --elevated-data-dir <path> \
+///   --elevated-data-local-dir <path> [opts] <subcommand> [args] \
+///   -- <cmd...>
+/// ```
+fn build_elevated_args(
+  creds: &PreElevationCreds,
+  env_file: &Path,
+  config_dir: Option<&Path>,
+  data_dir: Option<&Path>,
+  data_local_dir: Option<&Path>,
+) -> Vec<OsString> {
+  build_elevated_args_from(
+    std::env::args_os(),
+    creds,
+    env_file,
+    config_dir,
+    data_dir,
+    data_local_dir,
+  )
+}
+
+/// Testable inner implementation of [`build_elevated_args`].
+///
+/// `args` should include argv\[0\] (the program name), which is skipped.
+fn build_elevated_args_from(
+  args: impl IntoIterator<Item = impl Into<OsString>>,
+  creds: &PreElevationCreds,
+  env_file: &Path,
+  config_dir: Option<&Path>,
+  data_dir: Option<&Path>,
+  data_local_dir: Option<&Path>,
+) -> Vec<OsString> {
+  let mut result = Vec::new();
+  let mut replaced = false;
+  let mut past_delimiter = false;
+
+  for arg in args.into_iter().skip(1) {
+    let arg: OsString = arg.into();
+    if past_delimiter {
+      // After "--", pass everything through verbatim.
+      result.push(arg);
+      continue;
+    }
+    if arg == "--" {
+      past_delimiter = true;
+      result.push(arg);
+      continue;
+    }
+    if !replaced && arg == "--elevate" {
+      // Replace the first --elevate with --user/--restore-env-file and optional dir overrides.
+      replaced = true;
+      result.push(OsString::from("--user"));
+      result.push(OsString::from(&creds.username));
+      result.push(OsString::from("--restore-env-file"));
+      result.push(env_file.as_os_str().to_owned());
+      if let Some(dir) = config_dir {
+        result.push(OsString::from("--elevated-config-dir"));
+        result.push(dir.as_os_str().to_owned());
+      }
+      if let Some(dir) = data_dir {
+        result.push(OsString::from("--elevated-data-dir"));
+        result.push(dir.as_os_str().to_owned());
+      }
+      if let Some(dir) = data_local_dir {
+        result.push(OsString::from("--elevated-data-local-dir"));
+        result.push(dir.as_os_str().to_owned());
+      }
+    } else {
+      result.push(arg);
+    }
+  }
+
+  result
+}
+
+/// Re-execute tracexec with elevated privileges via sudo.
+///
+/// This function:
+/// 1. Saves the current environment to a secure temp file
+/// 2. Re-execs via `sudo` (without `-E`) with `--user <username>` and `--restore-env-file <path>`
+///
+/// This function does not return on success (it replaces the current process).
+pub fn elevate_and_reexec() -> color_eyre::Result<std::convert::Infallible> {
+  use std::os::unix::process::CommandExt;
+
+  if Uid::effective().is_root() {
+    color_eyre::eyre::bail!("--elevate is not needed when already running as root");
+  }
+
+  let creds = PreElevationCreds::capture()?;
+  let env_file = save_env_to_file()?;
+  let exe = std::env::current_exe()?;
+
+  // Capture the current user's project directories so the elevated process
+  // can use them instead of root's directories.
+  let proj_dirs = crate::cli::config::project_directory();
+  let config_dir = proj_dirs.as_ref().map(|d| d.config_dir().to_path_buf());
+  let data_dir = proj_dirs.as_ref().map(|d| d.data_dir().to_path_buf());
+  let data_local_dir = proj_dirs.as_ref().map(|d| d.data_local_dir().to_path_buf());
+  let elevated_args = build_elevated_args(
+    &creds,
+    &env_file,
+    config_dir.as_deref(),
+    data_dir.as_deref(),
+    data_local_dir.as_deref(),
+  );
+
+  tracing::debug!(
+    "Elevating: sudo {} {}",
+    exe.display(),
+    elevated_args
+      .iter()
+      .map(|a| a.to_string_lossy().to_string())
+      .collect::<Vec<_>>()
+      .join(" ")
+  );
+
+  let err = Command::new("sudo").arg(&exe).args(&elevated_args).exec();
+
+  // exec() only returns on error — clean up the env file
+  let _ = fs::remove_file(&env_file);
+  Err(err.into())
+}
+
+#[cfg(test)]
+mod tests {
+  use std::os::unix::ffi::OsStringExt;
+
+  use super::*;
+
+  #[test]
+  fn test_capture_creds() {
+    let creds = PreElevationCreds::capture().unwrap();
+    assert_eq!(creds.uid, nix::unistd::getuid().as_raw());
+    assert_eq!(creds.gid, nix::unistd::getgid().as_raw());
+    assert!(!creds.username.is_empty());
+  }
+
+  #[test]
+  fn test_serialize_deserialize_roundtrip() {
+    let original = vec![
+      (OsString::from("HOME"), OsString::from("/home/test")),
+      (OsString::from("PATH"), OsString::from("/usr/bin:/bin")),
+      (OsString::from("EMPTY"), OsString::from("")),
+      (OsString::from("MULTI_EQ"), OsString::from("a=b=c")),
+    ];
+
+    let mut buf = Vec::new();
+    for (k, v) in &original {
+      buf.extend_from_slice(k.as_bytes());
+      buf.push(b'=');
+      buf.extend_from_slice(v.as_bytes());
+      buf.push(0);
+    }
+
+    let deserialized = deserialize_env(&buf);
+    assert_eq!(deserialized, original);
+  }
+
+  #[test]
+  fn test_serialize_env_format() {
+    // serialize_env reads from the real env, just verify it produces null-terminated entries
+    let data = serialize_env();
+    if data.is_empty() {
+      return; // unlikely in a real test env
+    }
+    // Should end with a null byte (last entry's terminator)
+    assert_eq!(*data.last().unwrap(), 0u8);
+    // Every non-empty entry should contain '='
+    for entry in data.split(|&b| b == 0) {
+      if !entry.is_empty() {
+        assert!(
+          entry.contains(&b'='),
+          "entry missing '=': {:?}",
+          String::from_utf8_lossy(entry)
+        );
+      }
+    }
+  }
+
+  #[test]
+  fn test_deserialize_env_ignores_malformed() {
+    // Entries without '=' are silently skipped
+    let data = b"GOOD=value\0BAD_NO_EQUAL\0ALSO_GOOD=\0";
+    let result = deserialize_env(data);
+    assert_eq!(
+      result,
+      vec![
+        (OsString::from("GOOD"), OsString::from("value")),
+        (OsString::from("ALSO_GOOD"), OsString::from("")),
+      ]
+    );
+  }
+
+  #[test]
+  fn test_deserialize_env_handles_non_utf8() {
+    // Environment variables can contain non-UTF-8 bytes on Unix
+    let mut data = Vec::new();
+    data.extend_from_slice(b"KEY=");
+    data.extend_from_slice(&[0xff, 0xfe]); // non-UTF-8
+    data.push(0);
+
+    let result = deserialize_env(&data);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result[0].0, OsString::from("KEY"));
+    assert_eq!(result[0].1, OsString::from_vec(vec![0xff, 0xfe]));
+  }
+
+  #[test]
+  fn test_save_env_file() {
+    let env_file = save_env_to_file().unwrap();
+
+    // Verify the file exists and has correct permissions
+    let metadata = fs::metadata(&env_file).unwrap();
+    use std::os::unix::fs::MetadataExt;
+    assert_eq!(metadata.mode() & 0o7777, 0o600);
+    assert_eq!(metadata.uid(), nix::unistd::getuid().as_raw());
+
+    // Clean up: remove the file ourselves since we're not actually restoring
+    fs::remove_file(&env_file).unwrap();
+  }
+
+  #[test]
+  fn test_restore_env_rejects_symlink() {
+    let env_file = save_env_to_file().unwrap();
+    let symlink_path = env_file.with_extension("link");
+    std::os::unix::fs::symlink(&env_file, &symlink_path).unwrap();
+
+    // Opening a symlink with O_NOFOLLOW should fail
+    let result = restore_env_from_file(&symlink_path);
+    assert!(result.is_err());
+
+    let _ = fs::remove_file(&symlink_path);
+    let _ = fs::remove_file(&env_file);
+  }
+
+  #[test]
+  fn test_restore_env_preserves_values_in_subprocess() {
+    // We test that save + restore correctly round-trips by writing known values,
+    // saving, then restoring with the correct uid.
+    use std::os::unix::fs::PermissionsExt;
+
+    // Create a temp file with known env content
+    let dir = std::env::temp_dir();
+    let mut tmpfile = tempfile::Builder::new()
+      .prefix("tracexec-env-test-")
+      .tempfile_in(&dir)
+      .unwrap();
+
+    let test_env = b"TEST_RESTORE_A=hello_world\0TEST_RESTORE_B=foo=bar=baz\0TEST_RESTORE_C=\0";
+    tmpfile.write_all(test_env).unwrap();
+    tmpfile.flush().unwrap();
+    let path = tmpfile.into_temp_path().keep().unwrap();
+
+    // Verify permissions are 0600
+    let meta = fs::metadata(&path).unwrap();
+    assert_eq!(meta.permissions().mode() & 0o7777, 0o600);
+
+    let my_uid = nix::unistd::getuid().as_raw();
+
+    // We can't easily test the full env restoration in-process (it would
+    // clobber the test runner's env). Instead, verify the file passes
+    // all security checks by reading it manually the same way restore does.
+    let file = fs::OpenOptions::new()
+      .read(true)
+      .custom_flags(OFlag::O_NOFOLLOW.bits())
+      .open(&path)
+      .unwrap();
+    let fd_stat = stat::fstat(&file).unwrap();
+    assert_eq!(fd_stat.st_uid, my_uid);
+    assert_eq!(fd_stat.st_mode & 0o7777, 0o600);
+
+    let mut data = Vec::new();
+    let mut file = file;
+    file.read_to_end(&mut data).unwrap();
+    let restored = deserialize_env(&data);
+    assert_eq!(
+      restored,
+      vec![
+        (
+          OsString::from("TEST_RESTORE_A"),
+          OsString::from("hello_world")
+        ),
+        (
+          OsString::from("TEST_RESTORE_B"),
+          OsString::from("foo=bar=baz")
+        ),
+        (OsString::from("TEST_RESTORE_C"), OsString::from("")),
+      ]
+    );
+
+    let _ = fs::remove_file(&path);
+  }
+
+  #[test]
+  fn test_build_elevated_args_replaces_elevate() {
+    let creds = PreElevationCreds {
+      username: "testuser".to_string(),
+      uid: 1000,
+      gid: 1000,
+    };
+
+    let env_path = Path::new("/tmp/tracexec-env-abc123");
+
+    // Simulate: tracexec --elevate tui -t -- sudo ls
+    let input_args = vec![
+      OsString::from("tracexec"),
+      OsString::from("--elevate"),
+      OsString::from("tui"),
+      OsString::from("-t"),
+      OsString::from("--"),
+      OsString::from("sudo"),
+      OsString::from("ls"),
+    ];
+
+    let result = build_elevated_args_from(input_args, &creds, env_path, None, None, None);
+
+    assert_eq!(
+      result,
+      vec![
+        OsString::from("--user"),
+        OsString::from("testuser"),
+        OsString::from("--restore-env-file"),
+        OsString::from("/tmp/tracexec-env-abc123"),
+        OsString::from("tui"),
+        OsString::from("-t"),
+        OsString::from("--"),
+        OsString::from("sudo"),
+        OsString::from("ls"),
+      ]
+    );
+  }
+
+  #[test]
+  fn test_build_elevated_args_with_ebpf() {
+    let creds = PreElevationCreds {
+      username: "alice".to_string(),
+      uid: 1001,
+      gid: 100,
+    };
+
+    let env_path = Path::new("/tmp/tracexec-env-xyz");
+
+    // Simulate: tracexec --elevate ebpf tui -t -- bash
+    let input_args = vec![
+      OsString::from("tracexec"),
+      OsString::from("--elevate"),
+      OsString::from("ebpf"),
+      OsString::from("tui"),
+      OsString::from("-t"),
+      OsString::from("--"),
+      OsString::from("bash"),
+    ];
+
+    let result = build_elevated_args_from(input_args, &creds, env_path, None, None, None);
+
+    assert_eq!(
+      result,
+      vec![
+        OsString::from("--user"),
+        OsString::from("alice"),
+        OsString::from("--restore-env-file"),
+        OsString::from("/tmp/tracexec-env-xyz"),
+        OsString::from("ebpf"),
+        OsString::from("tui"),
+        OsString::from("-t"),
+        OsString::from("--"),
+        OsString::from("bash"),
+      ]
+    );
+  }
+
+  #[test]
+  fn test_build_elevated_args_preserves_other_flags() {
+    let creds = PreElevationCreds {
+      username: "bob".to_string(),
+      uid: 1002,
+      gid: 1002,
+    };
+
+    let env_path = Path::new("/tmp/tracexec-env-999");
+
+    // Simulate: tracexec --color=always --elevate -C /tmp log -- ls
+    let input_args = vec![
+      OsString::from("tracexec"),
+      OsString::from("--color=always"),
+      OsString::from("--elevate"),
+      OsString::from("-C"),
+      OsString::from("/tmp"),
+      OsString::from("log"),
+      OsString::from("--"),
+      OsString::from("ls"),
+    ];
+
+    let result = build_elevated_args_from(input_args, &creds, env_path, None, None, None);
+
+    assert_eq!(
+      result,
+      vec![
+        OsString::from("--color=always"),
+        OsString::from("--user"),
+        OsString::from("bob"),
+        OsString::from("--restore-env-file"),
+        OsString::from("/tmp/tracexec-env-999"),
+        OsString::from("-C"),
+        OsString::from("/tmp"),
+        OsString::from("log"),
+        OsString::from("--"),
+        OsString::from("ls"),
+      ]
+    );
+  }
+
+  #[test]
+  fn test_build_elevated_args_passes_project_dirs() {
+    let creds = PreElevationCreds {
+      username: "testuser".to_string(),
+      uid: 1000,
+      gid: 1000,
+    };
+
+    let env_path = Path::new("/tmp/tracexec-env-abc123");
+    let config_dir = Path::new("/home/testuser/.config/tracexec");
+    let data_dir = Path::new("/home/testuser/.local/share/tracexec");
+    let data_local_dir = Path::new("/home/testuser/.local/share/tracexec");
+
+    let input_args = vec![
+      OsString::from("tracexec"),
+      OsString::from("--elevate"),
+      OsString::from("log"),
+      OsString::from("--"),
+      OsString::from("ls"),
+    ];
+
+    let result = build_elevated_args_from(
+      input_args,
+      &creds,
+      env_path,
+      Some(config_dir),
+      Some(data_dir),
+      Some(data_local_dir),
+    );
+
+    assert_eq!(
+      result,
+      vec![
+        OsString::from("--user"),
+        OsString::from("testuser"),
+        OsString::from("--restore-env-file"),
+        OsString::from("/tmp/tracexec-env-abc123"),
+        OsString::from("--elevated-config-dir"),
+        OsString::from("/home/testuser/.config/tracexec"),
+        OsString::from("--elevated-data-dir"),
+        OsString::from("/home/testuser/.local/share/tracexec"),
+        OsString::from("--elevated-data-local-dir"),
+        OsString::from("/home/testuser/.local/share/tracexec"),
+        OsString::from("log"),
+        OsString::from("--"),
+        OsString::from("ls"),
+      ]
+    );
+  }
+
+  #[test]
+  fn test_build_elevated_args_ignores_elevate_after_delimiter() {
+    let creds = PreElevationCreds {
+      username: "testuser".to_string(),
+      uid: 1000,
+      gid: 1000,
+    };
+
+    let env_path = Path::new("/tmp/tracexec-env-abc123");
+
+    // Simulate: tracexec --elevate log -- cmd --elevate
+    // The --elevate after -- should NOT be replaced.
+    let input_args = vec![
+      OsString::from("tracexec"),
+      OsString::from("--elevate"),
+      OsString::from("log"),
+      OsString::from("--"),
+      OsString::from("cmd"),
+      OsString::from("--elevate"),
+    ];
+
+    let result = build_elevated_args_from(input_args, &creds, env_path, None, None, None);
+
+    assert_eq!(
+      result,
+      vec![
+        OsString::from("--user"),
+        OsString::from("testuser"),
+        OsString::from("--restore-env-file"),
+        OsString::from("/tmp/tracexec-env-abc123"),
+        OsString::from("log"),
+        OsString::from("--"),
+        OsString::from("cmd"),
+        OsString::from("--elevate"),
+      ]
+    );
+  }
+}

--- a/crates/tracexec-core/src/lib.rs
+++ b/crates/tracexec-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod breakpoint;
 pub mod cache;
 pub mod cli;
 pub mod cmdbuilder;
+pub mod elevate;
 pub mod event;
 pub mod export;
 pub mod output;

--- a/crates/tracexec-core/src/tracee.rs
+++ b/crates/tracexec-core/src/tracee.rs
@@ -1,12 +1,9 @@
 //! Common operations to run in tracee process
 
-use std::{
-  ffi::CString,
-  os::fd::{
-    AsFd,
-    FromRawFd,
-    OwnedFd,
-  },
+use std::os::fd::{
+  AsFd,
+  FromRawFd,
+  OwnedFd,
 };
 
 use nix::{
@@ -18,7 +15,6 @@ use nix::{
     User,
     dup2,
     getpid,
-    initgroups,
     setpgid,
     setresgid,
     setresuid,
@@ -45,10 +41,60 @@ pub fn nullify_stdio() -> Result<(), std::io::Error> {
 
 pub fn runas(user: &User, effective: Option<(Uid, Gid)>) -> Result<(), Errno> {
   let (euid, egid) = effective.unwrap_or((user.uid, user.gid));
-  initgroups(&CString::new(user.name.as_str()).unwrap()[..], user.gid)?;
+  do_initgroups(&user.name, user.gid)?;
   setresgid(user.gid, egid, Gid::from_raw(u32::MAX))?;
   setresuid(user.uid, euid, Uid::from_raw(u32::MAX))?;
   Ok(())
+}
+
+/// Parse `/etc/group` content to find supplementary group IDs for a user.
+///
+/// Returns a deduplicated list of GIDs including the primary GID.
+#[cfg(any(test, all(target_env = "gnu", target_feature = "crt-static")))]
+fn parse_supplementary_gids(etc_group_content: &str, username: &str, primary_gid: Gid) -> Vec<Gid> {
+  let mut gids = vec![primary_gid];
+  for line in etc_group_content.lines() {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with('#') {
+      continue;
+    }
+    // Format: group_name:password:GID:user_list
+    let mut fields = line.splitn(4, ':');
+    let Some(_name) = fields.next() else { continue };
+    let Some(_passwd) = fields.next() else {
+      continue;
+    };
+    let Some(gid_str) = fields.next() else {
+      continue;
+    };
+    let members = fields.next().unwrap_or("");
+    let Ok(gid_raw) = gid_str.parse::<u32>() else {
+      continue;
+    };
+    let gid = Gid::from_raw(gid_raw);
+    if members.split(',').any(|m| m.trim() == username) && !gids.contains(&gid) {
+      gids.push(gid);
+    }
+  }
+  gids
+}
+
+/// Set supplementary groups by reading `/etc/group` directly,
+/// avoiding dynamic NSS which crashes in static glibc builds.
+#[cfg(all(target_env = "gnu", target_feature = "crt-static"))]
+fn do_initgroups(username: &str, primary_gid: Gid) -> Result<(), Errno> {
+  let content = std::fs::read_to_string("/etc/group").map_err(|_| Errno::EIO)?;
+  let gids = parse_supplementary_gids(&content, username, primary_gid);
+  nix::unistd::setgroups(&gids)
+}
+
+/// Use the standard `initgroups` from libc for non-static-glibc builds.
+#[cfg(not(all(target_env = "gnu", target_feature = "crt-static")))]
+fn do_initgroups(username: &str, primary_gid: Gid) -> Result<(), Errno> {
+  nix::unistd::initgroups(
+    &std::ffi::CString::new(username).map_err(|_| Errno::EINVAL)?,
+    primary_gid,
+  )
 }
 
 pub fn lead_process_group() -> Result<(), Errno> {
@@ -111,5 +157,68 @@ mod tests {
       // Ensure we actually changed if not already leader
       let _ = pgrp_before;
     }
+  }
+
+  #[test]
+  fn test_parse_supplementary_gids_basic() {
+    let content =
+      "root:x:0:\ndaemon:x:1:\nusers:x:100:alice,bob\ndocker:x:999:alice\nwheel:x:10:bob\n";
+    let gids = parse_supplementary_gids(content, "alice", Gid::from_raw(1000));
+    assert_eq!(
+      gids,
+      vec![Gid::from_raw(1000), Gid::from_raw(100), Gid::from_raw(999)]
+    );
+  }
+
+  #[test]
+  fn test_parse_supplementary_gids_primary_gid_deduped() {
+    let content = "users:x:1000:alice\n";
+    let gids = parse_supplementary_gids(content, "alice", Gid::from_raw(1000));
+    // primary_gid 1000 already matched, should not be duplicated
+    assert_eq!(gids, vec![Gid::from_raw(1000)]);
+  }
+
+  #[test]
+  fn test_parse_supplementary_gids_no_members() {
+    let content = "root:x:0:\nusers:x:100:\n";
+    let gids = parse_supplementary_gids(content, "alice", Gid::from_raw(1000));
+    assert_eq!(gids, vec![Gid::from_raw(1000)]);
+  }
+
+  #[test]
+  fn test_parse_supplementary_gids_skips_malformed_lines() {
+    let content = "root:x:0:\nmalformed_line\n:x:abc:alice\nusers:x:100:alice\n";
+    let gids = parse_supplementary_gids(content, "alice", Gid::from_raw(1000));
+    assert_eq!(gids, vec![Gid::from_raw(1000), Gid::from_raw(100)]);
+  }
+
+  #[test]
+  fn test_parse_supplementary_gids_skips_comments_and_empty() {
+    let content = "# this is a comment\n\nusers:x:100:alice\n";
+    let gids = parse_supplementary_gids(content, "alice", Gid::from_raw(1000));
+    assert_eq!(gids, vec![Gid::from_raw(1000), Gid::from_raw(100)]);
+  }
+
+  #[test]
+  fn test_parse_supplementary_gids_no_partial_match() {
+    // "alice" should not match "alice2" or "malice"
+    let content = "group1:x:100:alice2,malice\ngroup2:x:200:alice\n";
+    let gids = parse_supplementary_gids(content, "alice", Gid::from_raw(1000));
+    assert_eq!(gids, vec![Gid::from_raw(1000), Gid::from_raw(200)]);
+  }
+
+  #[test]
+  fn test_parse_supplementary_gids_whitespace_in_members() {
+    let content = "group1:x:100: alice , bob \n";
+    let gids = parse_supplementary_gids(content, "alice", Gid::from_raw(1000));
+    assert_eq!(gids, vec![Gid::from_raw(1000), Gid::from_raw(100)]);
+  }
+
+  #[test]
+  fn test_parse_supplementary_gids_no_user_list_field() {
+    // Lines with only 3 fields (no user list)
+    let content = "nogroup:x:65534\n";
+    let gids = parse_supplementary_gids(content, "alice", Gid::from_raw(1000));
+    assert_eq!(gids, vec![Gid::from_raw(1000)]);
   }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,9 +78,35 @@ use tracexec_tui::{
 
 use crate::log::initialize_panic_handler;
 
-#[tokio::main(worker_threads = 2)]
-async fn main() -> color_eyre::Result<()> {
+// Avoid using tokio::main macro because we may need to restore env vars,
+// which is not completely safe inside a multithreaded process.
+fn main() -> color_eyre::Result<()> {
   let mut cli = Cli::parse();
+
+  // Handle --elevate early, before any environment-sensitive setup.
+  // This re-execs the process with elevated privileges and does not return.
+  if cli.elevate {
+    tracexec_core::elevate::elevate_and_reexec()?;
+    unreachable!();
+  }
+
+  // Restore saved environment from a previous --elevate invocation.
+  // This must happen before logging, config loading, or any code that reads env vars.
+  if let Some(env_file) = &cli.restore_env_file {
+    tracexec_core::elevate::restore_env_from_file(env_file)?;
+  }
+
+  // Apply project directory overrides from --elevate before anything
+  // touches project_directory() (logging, config, themes).
+  // The clap validation ensures that the three elevated_*_dir options are either all present or all absent.
+  if let (Some(config_dir), Some(data_dir), Some(data_local_dir)) = (
+    cli.elevated_config_dir.take(),
+    cli.elevated_data_dir.take(),
+    cli.elevated_data_local_dir.take(),
+  ) {
+    tracexec_core::cli::config::set_project_dir_overrides(config_dir, data_dir, data_local_dir);
+  }
+
   if cli.color == Color::Auto && std::env::var_os("NO_COLOR").is_some() {
     // Respect NO_COLOR if --color=auto
     cli.color = Color::Never;
@@ -96,6 +122,15 @@ async fn main() -> color_eyre::Result<()> {
   initialize_panic_handler();
   log::initialize_logging()?;
   log::debug!("Commandline args: {:?}", cli);
+
+  let runtime = tokio::runtime::Builder::new_multi_thread()
+    .worker_threads(2)
+    .enable_all()
+    .build()?;
+  runtime.block_on(async_main(cli))
+}
+
+async fn async_main(mut cli: Cli) -> color_eyre::Result<()> {
   if let Some(cwd) = &cli.cwd {
     std::env::set_current_dir(cwd)?;
   }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -20,3 +20,100 @@ fn log_mode_without_args_works() -> Result<(), Box<dyn std::error::Error>> {
     .stderr(predicate::str::contains("/proc/self/exe"));
   Ok(())
 }
+
+#[test]
+#[file_serial(ignored)]
+#[ignore = "root"]
+fn elevate_fails_when_already_root() -> Result<(), Box<dyn std::error::Error>> {
+  let mut cmd = Command::new(cargo::cargo_bin!());
+  cmd.arg("--elevate").arg("log").arg("--").arg("true");
+  cmd.assert().failure().stderr(predicate::str::contains(
+    "not needed when already running as root",
+  ));
+  Ok(())
+}
+
+#[test]
+#[file_serial(ignored)]
+#[ignore = "root"]
+fn elevate_log_mode_runs_tracee_as_original_user() -> Result<(), Box<dyn std::error::Error>> {
+  // This test must be run as root with: sudo -E cargo test
+  // It verifies that --user causes the tracee to run as the specified user.
+  let username = std::env::var("SUDO_USER").unwrap_or_else(|_| "nobody".to_string());
+  let mut cmd = Command::new(cargo::cargo_bin!());
+  cmd
+    .arg("--user")
+    .arg(&username)
+    .arg("log")
+    .arg("--")
+    .arg("id")
+    .arg("-un");
+  cmd
+    .assert()
+    .success()
+    .stdout(predicate::str::contains(&username));
+  Ok(())
+}
+
+#[test]
+#[file_serial(ignored)]
+#[ignore = "root"]
+fn elevate_env_file_preserves_custom_env_var() -> Result<(), Box<dyn std::error::Error>> {
+  // Test that --restore-env-file restores environment variables correctly.
+  // We create an env file with a known custom var AND SUDO_USER removed,
+  // then verify the tracee sees the custom var but not SUDO_USER.
+  use std::io::Write;
+
+  let username = std::env::var("SUDO_USER").unwrap_or_else(|_| "nobody".to_string());
+  let uid: u32 = std::env::var("SUDO_UID")
+    .ok()
+    .and_then(|s| s.parse().ok())
+    .unwrap_or(65534);
+
+  // Build env file content: include a test marker var and exclude SUDO_* vars
+  let mut env_data = Vec::new();
+  env_data.extend_from_slice(b"TRACEXEC_TEST_MARKER=preserved_value\0");
+  env_data.extend_from_slice(b"HOME=/tmp\0");
+  env_data
+    .extend_from_slice(format!("PATH={}\0", std::env::var("PATH").unwrap_or_default()).as_bytes());
+
+  // Write env file with correct permissions (0600) and ownership
+  let dir = std::env::temp_dir();
+  let mut tmpfile = tempfile::Builder::new()
+    .prefix("tracexec-env-test-")
+    .tempfile_in(&dir)?;
+  tmpfile.write_all(&env_data)?;
+  tmpfile.flush()?;
+  let env_path = tmpfile.into_temp_path();
+
+  // chown the file to the target user
+  nix::unistd::chown(
+    env_path.as_ref() as &std::path::Path,
+    Some(nix::unistd::Uid::from_raw(uid)),
+    None,
+  )?;
+
+  let mut cmd = Command::new(cargo::cargo_bin!());
+  cmd
+    .arg("--user")
+    .arg(&username)
+    .arg("--restore-env-file")
+    .arg(env_path.as_os_str())
+    .arg("log")
+    .arg("--")
+    .arg("sh")
+    .arg("-c")
+    .arg("echo MARKER=$TRACEXEC_TEST_MARKER SUDO=$SUDO_USER");
+  let output = cmd.output()?;
+  let stdout = String::from_utf8_lossy(&output.stdout);
+
+  assert!(
+    stdout.contains("MARKER=preserved_value"),
+    "Custom env var should be preserved, got stdout: {stdout}"
+  );
+  assert!(
+    stdout.contains("SUDO=\n"),
+    "SUDO_USER should be empty/absent, got stdout: {stdout}"
+  );
+  Ok(())
+}


### PR DESCRIPTION
Implement a convenient way for running privileged tracer but with unprivileged tracee.

Before: `sudo -E tracexec --user $(whoami) ebpf tui -t -- bash`.

After: `tracexec --elevate ebpf tui -t -- bash`

Also fix an unrelated bug with static build that got exposed in added tests:
`initgroups` still try to use dynamic nss plugins in static builds, leading to  segfault.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a privilege-elevation mode (--elevate) that re-runs the app via sudo while preserving the original environment and supporting elevated project-directory overrides.

* **Behavior Changes**
  * Elevation re-execs before normal startup; it's rejected when already root and conflicts with --user. Arguments after -- are preserved across re-exec.

* **Tests**
  * Added unit and smoke tests covering credential capture, env-file preservation/restoration, argument rewriting, and elevation scenarios.

* **Documentation**
  * New user guide: "Convenient Privilege Elevation" describing usage and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->