### PR TITLE
ukci: show test summary

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -69,7 +69,10 @@ jobs:
           skip-push: true
 
       # Run Userspace<->Kernel CI
-      - run: nix run '.#ukci'
+      - name: Run UKCI
+        env:
+          UKCI_SUMMARY_TITLE: UKCI (${{ matrix.os }})
+        run: nix run '.#ukci'
       - name: Add gc root for UKCI
         run: ln -s "$(nix eval --raw '.#ukci')" /nix/var/nix/gcroots/ukci
 
@@ -88,6 +91,9 @@ jobs:
       - *attic-rdonly
 
       # Run Userspace<->Kernel CI
-      - run: nix run '.#ukci-${{ matrix.arch }}'
+      - name: Run UKCI
+        env:
+          UKCI_SUMMARY_TITLE: UKCI (cross ${{ matrix.arch }})
+        run: nix run '.#ukci-${{ matrix.arch }}'
       - name: Add gc root for UKCI
         run: ln -s "$(nix eval --raw '.#ukci-${{ matrix.arch }}')" /nix/var/nix/gcroots/ukci

--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -433,7 +433,19 @@ localFlake:
                   echo "Missing package path!"
                   exit 1
                 fi
-                ${pkgs.nix}/bin/nix copy --to ssh://root@127.0.0.1 "$package"
+                attempt=0
+                while [ "$attempt" -lt 5 ]; do
+                  attempt=$((attempt + 1))
+                  if ${pkgs.nix}/bin/nix copy --to ssh://root@127.0.0.1 "$package"; then
+                    break
+                  fi
+                  if [ "$attempt" -eq 5 ]; then
+                    echo "nix copy failed after 5 attempts" >&2
+                    exit 1
+                  fi
+                  echo "nix copy failed (attempt $attempt/5), retrying..." >&2
+                  sleep 2
+                done
                 $ssh "$package"/bin/tracexec ebpf log -- ls
                 status=$?
                 exit "$status"

--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -330,6 +330,15 @@ localFlake:
                 "${name}:${targetSystem}:${test_exe}:${testPackage}"
               ) kernels;
               defaultPackage = if kernels == [ ] then "" else (builtins.head kernels).testPackage;
+              ukciSummaryHeader =
+                "| Kernel \ Clang | "
+                + lib.concatStringsSep " | " (map (v: "clang ${toString v}") llvmVersions)
+                + " |";
+              ukciSummarySep =
+                "| --- | "
+                + lib.concatStringsSep " | " (map (_: "---") llvmVersions)
+                + " |";
+              llvmVersionsSpaceSep = lib.concatStringsSep " " (map toString llvmVersions);
               runQemuDrv = pkgs.writeScriptBin runQemuName ''
                 #!/usr/bin/env bash
 
@@ -435,6 +444,7 @@ localFlake:
                 set -e
 
                 logs_dir="$(mktemp -d)"
+                results_dir="$(mktemp -d)"
                 lock_dir="$logs_dir/.lock"
                 status=0
                 running=0
@@ -493,6 +503,7 @@ localFlake:
                     else
                       echo "''${GREEN}''${BOLD}PASS:''${RESET} ''${name}"
                     fi
+                    printf '%s\n' "$test_status" > "$results_dir/$name"
                     rmdir "$lock_dir"
                     rm -f "$qemu_log" "$test_log"
                     exit "$test_status"
@@ -518,7 +529,55 @@ localFlake:
                   echo "''${YELLOW}''${BOLD}One or more tests failed.''${RESET}"
                 fi
 
-                rm -rf "$logs_dir"
+                summary_title="''${UKCI_SUMMARY_TITLE:-UKCI}"
+                render_summary_table() {
+                  echo "## $summary_title"
+                  echo ""
+                  echo "${ukciSummaryHeader}"
+                  echo "${ukciSummarySep}"
+                  declare -A seen_row=
+                  row_order=()
+                  for platform in ${platforms}; do
+                    IFS=: read -r pname _ts _te _pkg <<< "$platform"
+                    row_key="''${pname%-clang*}"
+                    if [ -z "''${seen_row[$row_key]+x}" ]; then
+                      seen_row[$row_key]=1
+                      row_order+=("$row_key")
+                    fi
+                  done
+                  for row_key in "''${row_order[@]}"; do
+                    line="| $row_key |"
+                    for llvm_ver in ${llvmVersionsSpaceSep}; do
+                      cell_name="$row_key-clang$llvm_ver"
+                      f="$results_dir/$cell_name"
+                      if [ -f "$f" ]; then
+                        ts="$(cat "$f")"
+                        if [ "$ts" -eq 0 ]; then
+                          cell="PASS"
+                        elif [ "$ts" -eq 124 ] || [ "$ts" -eq 137 ]; then
+                          cell="TIMEOUT"
+                        elif [ "$ts" -eq 143 ]; then
+                          cell="TERM"
+                        else
+                          cell="FAIL ($ts)"
+                        fi
+                      else
+                        cell="—"
+                      fi
+                      line="$line $cell |"
+                    done
+                    echo "$line"
+                  done
+                  echo ""
+                }
+                set +e
+                render_summary_table
+                if [ -n "''${GITHUB_STEP_SUMMARY:-}" ]; then
+                  render_summary_table >> "$GITHUB_STEP_SUMMARY"
+                fi
+                set -e
+
+                rm -rf "$logs_dir" "$results_dir"
                 exit "$status"
               '';
             in


### PR DESCRIPTION
Make it easier to discover what (kernel,LLVM) combination fails the test by showing a table output:

<img width="841" height="673" alt="image" src="https://github.com/user-attachments/assets/549f0587-cb1c-489b-883e-239601bfc84d" />

While at it, make the riscv64 tests less flaky by retrying the `nix copy` operation for up to 5 times.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Test results are now persisted and displayed in a summary table showing status across kernels and compiler versions in build reports.

* **Chores**
  * Enhanced CI workflow step identification for improved build tracking and visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->