### PR TITLE
ukci: add bpf-next to UKCI

### DIFF
--- a/nix/kernel-source.nix
+++ b/nix/kernel-source.nix
@@ -38,6 +38,7 @@ let
     mirror = "mirror://kernel/linux/kernel/v6.x/linux-${tag}.tar.xz";
     mirror-v5 = "mirror://kernel/linux/kernel/v5.x/linux-${tag}.tar.xz";
     linus = "https://github.com/torvalds/linux/archive/refs/tags/${tag}.tar.gz";
+    bpf-next = "https://git.kxxt.dev/kxxt/bpf-next/archive/${tag}.tar.gz";
   };
 in
 {

--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -176,7 +176,18 @@ localFlake:
               #   kernelPatches = [ riscv64BpfLocalStorageFix ];
               #   extraMakeFlags = [ ];
               # }
-            ];
+            ] ++ (lib.optionals (!isTargetRiscv64) [
+              {
+                name = "bpf-next";
+                tag = "bpf-next-7.1";
+                version = "7.0.0-rc6";
+                source = "bpf-next";
+                test_exe = "tracexec";
+                sha256 = "sha256-z9S4y2YCgsPoInlUTErvgJOj7OSy1c6xP443HXFPc/c=";
+                kernelPatches = [ ];
+                extraMakeFlags = [ ];
+              }
+            ]);
           sourcesForTargets =
             targetSystems:
             lib.concatMap (

--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -444,19 +444,7 @@ localFlake:
                   echo "Missing package path!"
                   exit 1
                 fi
-                attempt=0
-                while [ "$attempt" -lt 5 ]; do
-                  attempt=$((attempt + 1))
-                  if ${pkgs.nix}/bin/nix copy --to ssh://root@127.0.0.1 "$package"; then
-                    break
-                  fi
-                  if [ "$attempt" -eq 5 ]; then
-                    echo "nix copy failed after 5 attempts" >&2
-                    exit 1
-                  fi
-                  echo "nix copy failed (attempt $attempt/5), retrying..." >&2
-                  sleep 2
-                done
+                ${pkgs.nix}/bin/nix copy --to ssh://root@127.0.0.1 "$package"
                 $ssh "$package"/bin/tracexec ebpf log -- ls
                 status=$?
                 exit "$status"
@@ -503,15 +491,31 @@ localFlake:
                   test_log="$logs_dir/$name.test.log"
                   (
                     set +e
-                    ${runQemuDrv}/bin/${runQemuName} "$kernel" "$port" >"$qemu_log" 2>&1 &
-                    qemu_pid=$!
-                    ${pkgs.coreutils}/bin/timeout 600s \
-                      ${testQemuDrv}/bin/${testQemuName} "$test_exe" "$package" "$port" "1" >"$test_log" 2>&1
-                    test_status=$?
-                    if kill -0 "$qemu_pid" >/dev/null 2>&1; then
-                      kill "$qemu_pid" >/dev/null 2>&1 || true
-                    fi
-                    wait "$qemu_pid" 2>/dev/null || true
+                    max_vm_attempts="''${UKCI_VM_TEST_ATTEMPTS:-5}"
+                    attempt=1
+                    test_status=1
+                    while [ "$attempt" -le "$max_vm_attempts" ]; do
+                      if [ "$attempt" -gt 1 ]; then
+                        echo "''${YELLOW}''${BOLD}Retrying full VM test ''${name} (attempt $attempt/$max_vm_attempts)...''${RESET}" >&2
+                        sleep 3
+                      fi
+                      ${runQemuDrv}/bin/${runQemuName} "$kernel" "$port" >"$qemu_log" 2>&1 &
+                      qemu_pid=$!
+                      ${pkgs.coreutils}/bin/timeout 600s \
+                        ${testQemuDrv}/bin/${testQemuName} "$test_exe" "$package" "$port" "1" >"$test_log" 2>&1
+                      test_status=$?
+                      if kill -0 "$qemu_pid" >/dev/null 2>&1; then
+                        kill "$qemu_pid" >/dev/null 2>&1 || true
+                      fi
+                      wait "$qemu_pid" 2>/dev/null || true
+                      if [ "$test_status" -eq 0 ]; then
+                        break
+                      fi
+                      if [ "$attempt" -ge "$max_vm_attempts" ]; then
+                        break
+                      fi
+                      attempt=$((attempt + 1))
+                    done
                     while ! mkdir "$lock_dir" 2>/dev/null; do
                       sleep 0.1
                     done


### PR DESCRIPTION
To catch regressions from the kernel sooner, let's directly test with the latest tag from bpf-next.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the bpf-next kernel variant (version bpf-next-7.1 / 7.0.0-rc6) to the kernel source configuration.
  * This new kernel variant is now available across all target systems except riscv64-linux, expanding the range of kernel options available to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->