### PR TITLE
feat: replace env file with CLI args for --elevate env restore

### DIFF
--- a/crates/tracexec-core/src/cli.rs
+++ b/crates/tracexec-core/src/cli.rs
@@ -1,4 +1,5 @@
 use std::{
+  ffi::OsString,
   io::{
     BufWriter,
     stderr,
@@ -76,12 +77,12 @@ pub struct Cli {
   )]
   pub elevate: bool,
   #[arg(
-    long,
+    long = "restore-env",
     hide = true,
     conflicts_with = "elevate",
-    help = "Internal: path to a saved environment file from --elevate"
+    help = "Internal: restore an environment variable from --elevate (KEY=VALUE)"
   )]
-  pub restore_env_file: Option<PathBuf>,
+  pub restore_env: Vec<OsString>,
   #[arg(
     long,
     hide = true,
@@ -512,7 +513,7 @@ mod tests {
       no_profile: false,
       user: None,
       elevate: false,
-      restore_env_file: None,
+      restore_env: Vec::new(),
       elevated_config_dir: None,
       elevated_data_dir: None,
       elevated_data_local_dir: None,
@@ -571,7 +572,7 @@ mod tests {
       no_profile: false,
       user: None,
       elevate: false,
-      restore_env_file: None,
+      restore_env: Vec::new(),
       elevated_config_dir: None,
       elevated_data_dir: None,
       elevated_data_local_dir: None,
@@ -635,7 +636,7 @@ mod tests {
       no_profile: false,
       user: None,
       elevate: false,
-      restore_env_file: None,
+      restore_env: Vec::new(),
       elevated_config_dir: None,
       elevated_data_dir: None,
       elevated_data_local_dir: None,

--- a/crates/tracexec-core/src/elevate.rs
+++ b/crates/tracexec-core/src/elevate.rs
@@ -1,43 +1,25 @@
 //! Privilege elevation support for tracexec.
 //!
 //! When `--elevate` is used, tracexec captures the current user's credentials
-//! and environment variables, saves them to a secure temporary file, then
-//! re-executes itself with elevated privileges via `sudo`. The elevated process
-//! restores the original environment from the file and passes `--user <username>`
+//! and environment variables, then re-executes itself with elevated privileges
+//! via `sudo`. The elevated process restores the original environment from
+//! `--restore-env KEY=VALUE` CLI arguments and passes `--user <username>`
 //! so the tracee runs as the original user.
 //!
 //! ## Security
 //!
-//! The environment file is created with mode 0600 and owned by the current user.
-//! On restore, the file is opened with `O_NOFOLLOW` (rejecting symlinks), its
-//! metadata is checked via `fstat` (avoiding TOCTOU races), and it is unlinked
-//! immediately after reading. Only the original user and root can access it.
+//! Environment variables are passed as CLI arguments. The data is only visible
+//! to root (via /proc/<pid>/cmdline) after the sudo exec.
 
 use std::{
   ffi::OsString,
-  fs,
-  io::{
-    Read,
-    Write,
-  },
-  os::unix::{
-    ffi::OsStrExt,
-    fs::OpenOptionsExt,
-  },
-  path::Path,
+  os::unix::ffi::OsStrExt,
   process::Command,
 };
 
-use nix::{
-  fcntl::OFlag,
-  sys::stat::{
-    self,
-    SFlag,
-  },
-  unistd::{
-    Uid,
-    User,
-  },
+use nix::unistd::{
+  Uid,
+  User,
 };
 
 /// Saved credentials from before privilege elevation.
@@ -63,106 +45,41 @@ impl PreElevationCreds {
   }
 }
 
-/// Serialize all current environment variables into a byte buffer.
-///
-/// Uses the null-byte-separated `KEY=VALUE\0` format (same as `/proc/self/environ`).
-fn serialize_env() -> Vec<u8> {
-  let mut buf = Vec::new();
-  for (key, value) in std::env::vars_os() {
-    buf.extend_from_slice(key.as_bytes());
-    buf.push(b'=');
-    buf.extend_from_slice(value.as_bytes());
-    buf.push(0);
-  }
-  buf
+/// Capture all current environment variables as `KEY=VALUE` strings.
+fn capture_env_entries() -> Vec<OsString> {
+  std::env::vars_os()
+    .map(|(key, value)| {
+      let mut entry = OsString::with_capacity(key.len() + 1 + value.len());
+      entry.push(&key);
+      entry.push("=");
+      entry.push(&value);
+      entry
+    })
+    .collect()
 }
 
-/// Deserialize environment variables from null-byte-separated `KEY=VALUE\0` format.
-fn deserialize_env(data: &[u8]) -> Vec<(OsString, OsString)> {
-  use std::os::unix::ffi::OsStringExt;
-  let mut result = Vec::new();
-  for entry in data.split(|&b| b == 0) {
-    if entry.is_empty() {
-      continue;
-    }
-    if let Some(eq_pos) = entry.iter().position(|&b| b == b'=') {
-      let key = OsString::from_vec(entry[..eq_pos].to_vec());
-      let value = OsString::from_vec(entry[eq_pos + 1..].to_vec());
-      result.push((key, value));
-    }
-  }
-  result
-}
-
-/// Save the current environment to a temporary file with secure permissions.
-///
-/// Returns the path to the file. The file is created with mode 0600.
-fn save_env_to_file() -> color_eyre::Result<std::path::PathBuf> {
-  let dir = std::env::temp_dir();
-  let env_data = serialize_env();
-
-  // Create tempfile with a unique path, then write data to it.
-  // tempfile creates with mode 0600 by default on Unix.
-  let mut tmpfile = tempfile::Builder::new()
-    .prefix("tracexec-env-")
-    .tempfile_in(&dir)?;
-  tmpfile.write_all(&env_data)?;
-  tmpfile.flush()?;
-
-  // Persist so the file survives after we exec into sudo.
-  let path = tmpfile.into_temp_path().keep()?;
-  Ok(path)
-}
-
-/// Restore environment variables from a saved env file.
-///
-/// Security checks performed:
-/// - File is opened with `O_NOFOLLOW` to reject symlinks
-/// - `fstat` is used on the open fd to verify:
-///   - File is a regular file
-/// - File is unlinked immediately after reading
-pub fn restore_env_from_file(path: &Path) -> color_eyre::Result<()> {
-  // Open with O_NOFOLLOW to reject symlinks
-  let file = fs::OpenOptions::new()
-    .read(true)
-    .custom_flags(OFlag::O_NOFOLLOW.bits())
-    .open(path)
-    .map_err(|e| color_eyre::eyre::eyre!("Failed to open env file {}: {e}", path.display()))?;
-
-  let fd_stat = stat::fstat(&file)?;
-
-  // Verify it's a regular file
-  let file_type = SFlag::from_bits_truncate(fd_stat.st_mode & SFlag::S_IFMT.bits());
-  if file_type != SFlag::S_IFREG {
-    color_eyre::eyre::bail!(
-      "Env file {} is not a regular file (mode={:#o})",
-      path.display(),
-      fd_stat.st_mode
-    );
-  }
-
-  // Read the file contents
-  let mut data = Vec::new();
-  let mut file = file;
-  file.read_to_end(&mut data)?;
-
-  // Unlink immediately after reading
-  if let Err(e) = fs::remove_file(path) {
-    tracing::warn!("Failed to remove env file {}: {e}", path.display());
-  }
-
-  // Deserialize and restore
-  let saved_env = deserialize_env(&data);
-
-  // SAFETY: restore_env_from_file is called early in main.
+/// Restore environment variables from an iterator of `KEY=VALUE` entries.
+pub fn restore_env_from_entries(
+  entries: impl IntoIterator<Item = impl AsRef<std::ffi::OsStr>>,
+) -> color_eyre::Result<()> {
+  // SAFETY: restore_env_from_entries is called early in main.
   unsafe {
-    // Clear all current env vars
     for (key, _) in std::env::vars_os() {
       std::env::remove_var(&key);
     }
 
-    // Set the saved env vars
-    for (key, value) in saved_env {
+    for entry in entries {
+      let entry = entry.as_ref();
+      let bytes = entry.as_bytes();
+      let eq_pos = bytes.iter().position(|&b| b == b'=').ok_or_else(|| {
+        color_eyre::eyre::eyre!(
+          "Invalid --restore-env entry (missing '='): {}",
+          entry.to_string_lossy()
+        )
+      })?;
+      use std::os::unix::ffi::OsStringExt;
+      let key = OsString::from_vec(bytes[..eq_pos].to_vec());
+      let value = OsString::from_vec(bytes[eq_pos + 1..].to_vec());
       std::env::set_var(key, value);
     }
   }
@@ -176,22 +93,23 @@ pub fn restore_env_from_file(path: &Path) -> color_eyre::Result<()> {
 /// into
 ///
 /// ```bash
-/// sudo tracexec --user <username> --restore-env-file <path> \
+/// sudo tracexec --user <username> \
+///   --restore-env KEY1=VALUE1 --restore-env KEY2=VALUE2 ... \
 ///   --elevated-config-dir <path> --elevated-data-dir <path> \
 ///   --elevated-data-local-dir <path> [opts] <subcommand> [args] \
 ///   -- <cmd...>
 /// ```
 fn build_elevated_args(
   creds: &PreElevationCreds,
-  env_file: &Path,
-  config_dir: Option<&Path>,
-  data_dir: Option<&Path>,
-  data_local_dir: Option<&Path>,
+  env_entries: &[OsString],
+  config_dir: Option<&std::path::Path>,
+  data_dir: Option<&std::path::Path>,
+  data_local_dir: Option<&std::path::Path>,
 ) -> Vec<OsString> {
   build_elevated_args_from(
     std::env::args_os(),
     creds,
-    env_file,
+    env_entries,
     config_dir,
     data_dir,
     data_local_dir,
@@ -204,10 +122,10 @@ fn build_elevated_args(
 fn build_elevated_args_from(
   args: impl IntoIterator<Item = impl Into<OsString>>,
   creds: &PreElevationCreds,
-  env_file: &Path,
-  config_dir: Option<&Path>,
-  data_dir: Option<&Path>,
-  data_local_dir: Option<&Path>,
+  env_entries: &[OsString],
+  config_dir: Option<&std::path::Path>,
+  data_dir: Option<&std::path::Path>,
+  data_local_dir: Option<&std::path::Path>,
 ) -> Vec<OsString> {
   let mut result = Vec::new();
   let mut replaced = false;
@@ -216,7 +134,6 @@ fn build_elevated_args_from(
   for arg in args.into_iter().skip(1) {
     let arg: OsString = arg.into();
     if past_delimiter {
-      // After "--", pass everything through verbatim.
       result.push(arg);
       continue;
     }
@@ -226,12 +143,13 @@ fn build_elevated_args_from(
       continue;
     }
     if !replaced && arg == "--elevate" {
-      // Replace the first --elevate with --user/--restore-env-file and optional dir overrides.
       replaced = true;
       result.push(OsString::from("--user"));
       result.push(OsString::from(&creds.username));
-      result.push(OsString::from("--restore-env-file"));
-      result.push(env_file.as_os_str().to_owned());
+      for entry in env_entries {
+        result.push(OsString::from("--restore-env"));
+        result.push(entry.clone());
+      }
       if let Some(dir) = config_dir {
         result.push(OsString::from("--elevated-config-dir"));
         result.push(dir.as_os_str().to_owned());
@@ -255,8 +173,9 @@ fn build_elevated_args_from(
 /// Re-execute tracexec with elevated privileges via sudo.
 ///
 /// This function:
-/// 1. Saves the current environment to a secure temp file
-/// 2. Re-execs via `sudo` (without `-E`) with `--user <username>` and `--restore-env-file <path>`
+/// 1. Captures the current environment
+/// 2. Re-execs via `sudo` (without `-E`) with `--user <username>` and
+///    `--restore-env KEY=VALUE` for each env var
 ///
 /// This function does not return on success (it replaces the current process).
 pub fn elevate_and_reexec() -> color_eyre::Result<std::convert::Infallible> {
@@ -267,7 +186,7 @@ pub fn elevate_and_reexec() -> color_eyre::Result<std::convert::Infallible> {
   }
 
   let creds = PreElevationCreds::capture()?;
-  let env_file = save_env_to_file()?;
+  let env_entries = capture_env_entries();
   let exe = std::env::current_exe()?;
 
   // Capture the current user's project directories so the elevated process
@@ -278,26 +197,20 @@ pub fn elevate_and_reexec() -> color_eyre::Result<std::convert::Infallible> {
   let data_local_dir = proj_dirs.as_ref().map(|d| d.data_local_dir().to_path_buf());
   let elevated_args = build_elevated_args(
     &creds,
-    &env_file,
+    &env_entries,
     config_dir.as_deref(),
     data_dir.as_deref(),
     data_local_dir.as_deref(),
   );
 
   tracing::debug!(
-    "Elevating: sudo {} {}",
+    "Elevating: sudo {} --user {} --restore-env ...",
     exe.display(),
-    elevated_args
-      .iter()
-      .map(|a| a.to_string_lossy().to_string())
-      .collect::<Vec<_>>()
-      .join(" ")
+    creds.username,
   );
 
   let err = Command::new("sudo").arg(&exe).args(&elevated_args).exec();
 
-  // exec() only returns on error — clean up the env file
-  let _ = fs::remove_file(&env_file);
   Err(err.into())
 }
 
@@ -316,159 +229,80 @@ mod tests {
   }
 
   #[test]
-  fn test_serialize_deserialize_roundtrip() {
-    let original = vec![
-      (OsString::from("HOME"), OsString::from("/home/test")),
-      (OsString::from("PATH"), OsString::from("/usr/bin:/bin")),
-      (OsString::from("EMPTY"), OsString::from("")),
-      (OsString::from("MULTI_EQ"), OsString::from("a=b=c")),
+  fn test_capture_env_entries_format() {
+    let entries = capture_env_entries();
+    for entry in &entries {
+      let bytes = entry.as_bytes();
+      assert!(
+        bytes.contains(&b'='),
+        "entry missing '=': {:?}",
+        String::from_utf8_lossy(bytes)
+      );
+    }
+  }
+
+  #[test]
+  fn test_restore_env_from_entries_roundtrip() {
+    let entries: Vec<OsString> = vec![
+      OsString::from("HOME=/home/test"),
+      OsString::from("PATH=/usr/bin:/bin"),
+      OsString::from("EMPTY="),
+      OsString::from("MULTI_EQ=a=b=c"),
     ];
 
-    let mut buf = Vec::new();
-    for (k, v) in &original {
-      buf.extend_from_slice(k.as_bytes());
-      buf.push(b'=');
-      buf.extend_from_slice(v.as_bytes());
-      buf.push(0);
-    }
-
-    let deserialized = deserialize_env(&buf);
-    assert_eq!(deserialized, original);
-  }
-
-  #[test]
-  fn test_serialize_env_format() {
-    // serialize_env reads from the real env, just verify it produces null-terminated entries
-    let data = serialize_env();
-    if data.is_empty() {
-      return; // unlikely in a real test env
-    }
-    // Should end with a null byte (last entry's terminator)
-    assert_eq!(*data.last().unwrap(), 0u8);
-    // Every non-empty entry should contain '='
-    for entry in data.split(|&b| b == 0) {
-      if !entry.is_empty() {
-        assert!(
-          entry.contains(&b'='),
-          "entry missing '=': {:?}",
-          String::from_utf8_lossy(entry)
-        );
-      }
-    }
-  }
-
-  #[test]
-  fn test_deserialize_env_ignores_malformed() {
-    // Entries without '=' are silently skipped
-    let data = b"GOOD=value\0BAD_NO_EQUAL\0ALSO_GOOD=\0";
-    let result = deserialize_env(data);
-    assert_eq!(
-      result,
-      vec![
-        (OsString::from("GOOD"), OsString::from("value")),
-        (OsString::from("ALSO_GOOD"), OsString::from("")),
-      ]
-    );
-  }
-
-  #[test]
-  fn test_deserialize_env_handles_non_utf8() {
-    // Environment variables can contain non-UTF-8 bytes on Unix
-    let mut data = Vec::new();
-    data.extend_from_slice(b"KEY=");
-    data.extend_from_slice(&[0xff, 0xfe]); // non-UTF-8
-    data.push(0);
-
-    let result = deserialize_env(&data);
-    assert_eq!(result.len(), 1);
-    assert_eq!(result[0].0, OsString::from("KEY"));
-    assert_eq!(result[0].1, OsString::from_vec(vec![0xff, 0xfe]));
-  }
-
-  #[test]
-  fn test_save_env_file() {
-    let env_file = save_env_to_file().unwrap();
-
-    // Verify the file exists and has correct permissions
-    let metadata = fs::metadata(&env_file).unwrap();
-    use std::os::unix::fs::MetadataExt;
-    assert_eq!(metadata.mode() & 0o7777, 0o600);
-    assert_eq!(metadata.uid(), nix::unistd::getuid().as_raw());
-
-    // Clean up: remove the file ourselves since we're not actually restoring
-    fs::remove_file(&env_file).unwrap();
-  }
-
-  #[test]
-  fn test_restore_env_rejects_symlink() {
-    let env_file = save_env_to_file().unwrap();
-    let symlink_path = env_file.with_extension("link");
-    std::os::unix::fs::symlink(&env_file, &symlink_path).unwrap();
-
-    // Opening a symlink with O_NOFOLLOW should fail
-    let result = restore_env_from_file(&symlink_path);
-    assert!(result.is_err());
-
-    let _ = fs::remove_file(&symlink_path);
-    let _ = fs::remove_file(&env_file);
-  }
-
-  #[test]
-  fn test_restore_env_preserves_values_in_subprocess() {
-    // We test that save + restore correctly round-trips by writing known values,
-    // saving, then restoring with the correct uid.
-    use std::os::unix::fs::PermissionsExt;
-
-    // Create a temp file with known env content
-    let dir = std::env::temp_dir();
-    let mut tmpfile = tempfile::Builder::new()
-      .prefix("tracexec-env-test-")
-      .tempfile_in(&dir)
-      .unwrap();
-
-    let test_env = b"TEST_RESTORE_A=hello_world\0TEST_RESTORE_B=foo=bar=baz\0TEST_RESTORE_C=\0";
-    tmpfile.write_all(test_env).unwrap();
-    tmpfile.flush().unwrap();
-    let path = tmpfile.into_temp_path().keep().unwrap();
-
-    // Verify permissions are 0600
-    let meta = fs::metadata(&path).unwrap();
-    assert_eq!(meta.permissions().mode() & 0o7777, 0o600);
-
-    let my_uid = nix::unistd::getuid().as_raw();
-
-    // We can't easily test the full env restoration in-process (it would
-    // clobber the test runner's env). Instead, verify the file passes
-    // all security checks by reading it manually the same way restore does.
-    let file = fs::OpenOptions::new()
-      .read(true)
-      .custom_flags(OFlag::O_NOFOLLOW.bits())
-      .open(&path)
-      .unwrap();
-    let fd_stat = stat::fstat(&file).unwrap();
-    assert_eq!(fd_stat.st_uid, my_uid);
-    assert_eq!(fd_stat.st_mode & 0o7777, 0o600);
-
-    let mut data = Vec::new();
-    let mut file = file;
-    file.read_to_end(&mut data).unwrap();
-    let restored = deserialize_env(&data);
-    assert_eq!(
-      restored,
-      vec![
+    // Can't easily test in-process restoration (clobbers test env),
+    // but verify parsing doesn't panic
+    let parsed: Vec<_> = entries
+      .iter()
+      .map(|e| {
+        let bytes = e.as_bytes();
+        let eq = bytes.iter().position(|&b| b == b'=').unwrap();
         (
-          OsString::from("TEST_RESTORE_A"),
-          OsString::from("hello_world")
-        ),
-        (
-          OsString::from("TEST_RESTORE_B"),
-          OsString::from("foo=bar=baz")
-        ),
-        (OsString::from("TEST_RESTORE_C"), OsString::from("")),
-      ]
-    );
+          OsString::from_vec(bytes[..eq].to_vec()),
+          OsString::from_vec(bytes[eq + 1..].to_vec()),
+        )
+      })
+      .collect();
 
-    let _ = fs::remove_file(&path);
+    assert_eq!(parsed[0].0, "HOME");
+    assert_eq!(parsed[0].1, "/home/test");
+    assert_eq!(parsed[3].0, "MULTI_EQ");
+    assert_eq!(parsed[3].1, "a=b=c");
+  }
+
+  #[test]
+  fn test_restore_env_handles_non_utf8() {
+    let mut entry = vec![];
+    entry.extend_from_slice(b"KEY=");
+    entry.extend_from_slice(&[0xff, 0xfe]);
+    let entries = vec![OsString::from_vec(entry)];
+
+    let parsed: Vec<_> = entries
+      .iter()
+      .map(|e| {
+        let bytes = e.as_bytes();
+        let eq = bytes.iter().position(|&b| b == b'=').unwrap();
+        (
+          OsString::from_vec(bytes[..eq].to_vec()),
+          OsString::from_vec(bytes[eq + 1..].to_vec()),
+        )
+      })
+      .collect();
+
+    assert_eq!(parsed[0].0, "KEY");
+    assert_eq!(parsed[0].1, OsString::from_vec(vec![0xff, 0xfe]));
+  }
+
+  #[test]
+  fn test_restore_env_from_entries_rejects_missing_equals() {
+    // Only test the validation logic, not the full restore (which clobbers env)
+    let entry = OsString::from("INVALID_WITHOUT_EQUALS");
+    let bytes = entry.as_bytes();
+    let result = bytes.iter().position(|&b| b == b'=');
+    assert!(
+      result.is_none(),
+      "entry without '=' should have no equals sign"
+    );
   }
 
   #[test]
@@ -479,9 +313,11 @@ mod tests {
       gid: 1000,
     };
 
-    let env_path = Path::new("/tmp/tracexec-env-abc123");
+    let env_entries = vec![
+      OsString::from("HOME=/home/testuser"),
+      OsString::from("PATH=/usr/bin"),
+    ];
 
-    // Simulate: tracexec --elevate tui -t -- sudo ls
     let input_args = vec![
       OsString::from("tracexec"),
       OsString::from("--elevate"),
@@ -492,15 +328,17 @@ mod tests {
       OsString::from("ls"),
     ];
 
-    let result = build_elevated_args_from(input_args, &creds, env_path, None, None, None);
+    let result = build_elevated_args_from(input_args, &creds, &env_entries, None, None, None);
 
     assert_eq!(
       result,
       vec![
         OsString::from("--user"),
         OsString::from("testuser"),
-        OsString::from("--restore-env-file"),
-        OsString::from("/tmp/tracexec-env-abc123"),
+        OsString::from("--restore-env"),
+        OsString::from("HOME=/home/testuser"),
+        OsString::from("--restore-env"),
+        OsString::from("PATH=/usr/bin"),
         OsString::from("tui"),
         OsString::from("-t"),
         OsString::from("--"),
@@ -518,9 +356,8 @@ mod tests {
       gid: 100,
     };
 
-    let env_path = Path::new("/tmp/tracexec-env-xyz");
+    let env_entries = vec![OsString::from("HOME=/home/alice")];
 
-    // Simulate: tracexec --elevate ebpf tui -t -- bash
     let input_args = vec![
       OsString::from("tracexec"),
       OsString::from("--elevate"),
@@ -531,15 +368,15 @@ mod tests {
       OsString::from("bash"),
     ];
 
-    let result = build_elevated_args_from(input_args, &creds, env_path, None, None, None);
+    let result = build_elevated_args_from(input_args, &creds, &env_entries, None, None, None);
 
     assert_eq!(
       result,
       vec![
         OsString::from("--user"),
         OsString::from("alice"),
-        OsString::from("--restore-env-file"),
-        OsString::from("/tmp/tracexec-env-xyz"),
+        OsString::from("--restore-env"),
+        OsString::from("HOME=/home/alice"),
         OsString::from("ebpf"),
         OsString::from("tui"),
         OsString::from("-t"),
@@ -557,9 +394,8 @@ mod tests {
       gid: 1002,
     };
 
-    let env_path = Path::new("/tmp/tracexec-env-999");
+    let env_entries = vec![];
 
-    // Simulate: tracexec --color=always --elevate -C /tmp log -- ls
     let input_args = vec![
       OsString::from("tracexec"),
       OsString::from("--color=always"),
@@ -571,7 +407,7 @@ mod tests {
       OsString::from("ls"),
     ];
 
-    let result = build_elevated_args_from(input_args, &creds, env_path, None, None, None);
+    let result = build_elevated_args_from(input_args, &creds, &env_entries, None, None, None);
 
     assert_eq!(
       result,
@@ -579,8 +415,6 @@ mod tests {
         OsString::from("--color=always"),
         OsString::from("--user"),
         OsString::from("bob"),
-        OsString::from("--restore-env-file"),
-        OsString::from("/tmp/tracexec-env-999"),
         OsString::from("-C"),
         OsString::from("/tmp"),
         OsString::from("log"),
@@ -598,10 +432,10 @@ mod tests {
       gid: 1000,
     };
 
-    let env_path = Path::new("/tmp/tracexec-env-abc123");
-    let config_dir = Path::new("/home/testuser/.config/tracexec");
-    let data_dir = Path::new("/home/testuser/.local/share/tracexec");
-    let data_local_dir = Path::new("/home/testuser/.local/share/tracexec");
+    let env_entries = vec![OsString::from("TERM=xterm")];
+    let config_dir = std::path::Path::new("/home/testuser/.config/tracexec");
+    let data_dir = std::path::Path::new("/home/testuser/.local/share/tracexec");
+    let data_local_dir = std::path::Path::new("/home/testuser/.local/share/tracexec");
 
     let input_args = vec![
       OsString::from("tracexec"),
@@ -614,7 +448,7 @@ mod tests {
     let result = build_elevated_args_from(
       input_args,
       &creds,
-      env_path,
+      &env_entries,
       Some(config_dir),
       Some(data_dir),
       Some(data_local_dir),
@@ -625,8 +459,8 @@ mod tests {
       vec![
         OsString::from("--user"),
         OsString::from("testuser"),
-        OsString::from("--restore-env-file"),
-        OsString::from("/tmp/tracexec-env-abc123"),
+        OsString::from("--restore-env"),
+        OsString::from("TERM=xterm"),
         OsString::from("--elevated-config-dir"),
         OsString::from("/home/testuser/.config/tracexec"),
         OsString::from("--elevated-data-dir"),
@@ -648,10 +482,8 @@ mod tests {
       gid: 1000,
     };
 
-    let env_path = Path::new("/tmp/tracexec-env-abc123");
+    let env_entries = vec![];
 
-    // Simulate: tracexec --elevate log -- cmd --elevate
-    // The --elevate after -- should NOT be replaced.
     let input_args = vec![
       OsString::from("tracexec"),
       OsString::from("--elevate"),
@@ -661,15 +493,13 @@ mod tests {
       OsString::from("--elevate"),
     ];
 
-    let result = build_elevated_args_from(input_args, &creds, env_path, None, None, None);
+    let result = build_elevated_args_from(input_args, &creds, &env_entries, None, None, None);
 
     assert_eq!(
       result,
       vec![
         OsString::from("--user"),
         OsString::from("testuser"),
-        OsString::from("--restore-env-file"),
-        OsString::from("/tmp/tracexec-env-abc123"),
         OsString::from("log"),
         OsString::from("--"),
         OsString::from("cmd"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,8 +92,8 @@ fn main() -> color_eyre::Result<()> {
 
   // Restore saved environment from a previous --elevate invocation.
   // This must happen before logging, config loading, or any code that reads env vars.
-  if let Some(env_file) = &cli.restore_env_file {
-    tracexec_core::elevate::restore_env_from_file(env_file)?;
+  if !cli.restore_env.is_empty() {
+    tracexec_core::elevate::restore_env_from_entries(&cli.restore_env)?;
   }
 
   // Apply project directory overrides from --elevate before anything

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -58,47 +58,24 @@ fn elevate_log_mode_runs_tracee_as_original_user() -> Result<(), Box<dyn std::er
 #[test]
 #[file_serial(ignored)]
 #[ignore = "root"]
-fn elevate_env_file_preserves_custom_env_var() -> Result<(), Box<dyn std::error::Error>> {
-  // Test that --restore-env-file restores environment variables correctly.
-  // We create an env file with a known custom var AND SUDO_USER removed,
-  // then verify the tracee sees the custom var but not SUDO_USER.
-  use std::io::Write;
-
+fn elevate_restore_env_preserves_custom_env_var() -> Result<(), Box<dyn std::error::Error>> {
+  // Test that --restore-env restores environment variables correctly.
+  // Pass env entries via CLI args and verify the tracee sees them but not SUDO_USER.
   let username = std::env::var("SUDO_USER").unwrap_or_else(|_| "nobody".to_string());
-  let uid: u32 = std::env::var("SUDO_UID")
-    .ok()
-    .and_then(|s| s.parse().ok())
-    .unwrap_or(65534);
-
-  // Build env file content: include a test marker var and exclude SUDO_* vars
-  let mut env_data = Vec::new();
-  env_data.extend_from_slice(b"TRACEXEC_TEST_MARKER=preserved_value\0");
-  env_data.extend_from_slice(b"HOME=/tmp\0");
-  env_data
-    .extend_from_slice(format!("PATH={}\0", std::env::var("PATH").unwrap_or_default()).as_bytes());
-
-  // Write env file with correct permissions (0600) and ownership
-  let dir = std::env::temp_dir();
-  let mut tmpfile = tempfile::Builder::new()
-    .prefix("tracexec-env-test-")
-    .tempfile_in(&dir)?;
-  tmpfile.write_all(&env_data)?;
-  tmpfile.flush()?;
-  let env_path = tmpfile.into_temp_path();
-
-  // chown the file to the target user
-  nix::unistd::chown(
-    env_path.as_ref() as &std::path::Path,
-    Some(nix::unistd::Uid::from_raw(uid)),
-    None,
-  )?;
 
   let mut cmd = Command::new(cargo::cargo_bin!());
   cmd
     .arg("--user")
     .arg(&username)
-    .arg("--restore-env-file")
-    .arg(env_path.as_os_str())
+    .arg("--restore-env")
+    .arg("TRACEXEC_TEST_MARKER=preserved_value")
+    .arg("--restore-env")
+    .arg("HOME=/tmp")
+    .arg("--restore-env")
+    .arg(format!(
+      "PATH={}",
+      std::env::var("PATH").unwrap_or_default()
+    ))
     .arg("log")
     .arg("--")
     .arg("sh")


### PR DESCRIPTION
Pass each environment variable as a separate --restore-env KEY=VALUE argument instead of writing to a temp file and passing --restore-env-file. This eliminates the file-based TOCTOU surface and the need for temp file security checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal mechanisms for environment variable restoration during privilege elevation operations to enhance security handling and code maintainability.
  * Updated internal test suite to validate the revised environment restoration implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->