### PR TITLE
ukci: bump nix to 2.31.2

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -45,11 +45,12 @@ jobs:
       - &install-nix
         uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
         with:
+          nix_version: 2.31.2
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
             http2 = false
-          
+
       - &attic-writable
         name: Setup Attic cache (Writable)
         uses: ryanccn/attic-action@1887fd507f03327c96c64cca30118c96eb17fdad # v0.4.1
@@ -58,7 +59,7 @@ jobs:
           endpoint: https://nix.kxxt.dev
           cache: tracexec
           token: ${{ secrets.NIX_CACHE_JWT }}
-      
+
       - &attic-rdonly
         name: Setup Attic cache (ReadOnly)
         uses: ryanccn/attic-action@1887fd507f03327c96c64cca30118c96eb17fdad # v0.4.1
@@ -85,9 +86,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - *install-nix
-          
+
       - *attic-writable
-      
+
       - *attic-rdonly
 
       # Run Userspace<->Kernel CI


### PR DESCRIPTION
For unblocking https://github.com/kxxt/tracexec/pull/211

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration configuration to ensure consistent and reproducible build environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kxxt/tracexec/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->