### PR TITLE
ukci: switch to cachix/install-nix-action

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -43,10 +43,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - &install-nix
-        uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
         with:
-          nix_version: 2.31.2
-          nix_conf: |
+          extra_nix_config: |
             keep-env-derivations = true
             keep-outputs = true
             http2 = false
@@ -75,7 +74,7 @@ jobs:
           UKCI_SUMMARY_TITLE: UKCI (${{ matrix.os }})
         run: nix run '.#ukci'
       - name: Add gc root for UKCI
-        run: ln -s "$(nix eval --raw '.#ukci')" /nix/var/nix/gcroots/ukci
+        run: sudo ln -s "$(nix eval --raw '.#ukci')" /nix/var/nix/gcroots/ukci
 
   nix-cross:
     strategy:
@@ -97,4 +96,4 @@ jobs:
           UKCI_SUMMARY_TITLE: UKCI (cross ${{ matrix.arch }})
         run: nix run '.#ukci-${{ matrix.arch }}'
       - name: Add gc root for UKCI
-        run: ln -s "$(nix eval --raw '.#ukci-${{ matrix.arch }}')" /nix/var/nix/gcroots/ukci
+        run: sudo ln -s "$(nix eval --raw '.#ukci-${{ matrix.arch }}')" /nix/var/nix/gcroots/ukci


### PR DESCRIPTION
It appears the official action is less maintained than this one. The official one does not support Nix 2.34 by now.