### PR TITLE
fix: use UDS for env restore with allowlist filter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1684,6 +1684,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -3212,6 +3213,7 @@ dependencies = [
  "nix 0.31.1",
  "nutype",
  "paste",
+ "rand 0.10.1",
  "regex-cursor",
  "rusty-fork",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ nix = { version = "0.31", features = [
     "ptrace",
     "process",
     "feature",
+    "socket",
     "term",
     "fs",
     "signal",

--- a/crates/tracexec-backend-ebpf/src/probe.rs
+++ b/crates/tracexec-backend-ebpf/src/probe.rs
@@ -2,12 +2,12 @@
 
 use std::{
   collections::HashMap,
-  env,
+  ffi::OsString,
 };
 
 use cfg_if::cfg_if;
 use procfs::ConfigSetting;
-use tracing::warn;
+use tracexec_core::elevate;
 
 pub fn kernel_have_syscall_wrappers(
   #[allow(unused)] kconfig: Option<&HashMap<String, ConfigSetting>>,
@@ -28,17 +28,16 @@ pub fn kernel_have_syscall_wrappers(
 
 pub fn kernel_have_ftrace_with_direct_calls(
   kconfig: Option<&HashMap<String, ConfigSetting>>,
+  override_env: Option<&[(OsString, OsString)]>,
 ) -> bool {
   // First, check special env `TRACEXEC_USE_KPROBE`
-  if env::var("TRACEXEC_USE_KPROBE")
-    .inspect_err(|e| warn!("Failed to read env TRACEXEC_USE_KPROBE: {e}"))
+  if elevate::env_var_string(override_env, "TRACEXEC_USE_KPROBE")
     .map(|v| !v.is_empty())
     .unwrap_or_default()
   {
     return false;
   }
-  env::var("TRACEXEC_USE_FENTRY")
-    .inspect_err(|e| warn!("Failed to read env TRACEXEC_USE_FENTRY: {e}"))
+  elevate::env_var_string(override_env, "TRACEXEC_USE_FENTRY")
     .map(|v| !v.is_empty())
     .unwrap_or_default() ||
   // Then, we try to read kernel config
@@ -64,8 +63,11 @@ pub fn kernel_have_ftrace_with_direct_calls(
   }
 }
 
-pub fn can_i_use_sleepable_fentry(kconfig: Option<&HashMap<String, ConfigSetting>>) -> bool {
-  if env::var("TRACEXEC_NO_SLEEP")
+pub fn can_i_use_sleepable_fentry(
+  kconfig: Option<&HashMap<String, ConfigSetting>>,
+  override_env: Option<&[(OsString, OsString)]>,
+) -> bool {
+  if elevate::env_var_string(override_env, "TRACEXEC_NO_SLEEP")
     .map(|v| !v.is_empty())
     .unwrap_or_default()
   {
@@ -105,7 +107,7 @@ mod tests {
         "CONFIG_FUNCTION_ERROR_INJECTION".to_string(),
         ConfigSetting::Yes,
       );
-      assert!(!can_i_use_sleepable_fentry(Some(&configs)));
+      assert!(!can_i_use_sleepable_fentry(Some(&configs), None));
     }
 
     #[test]
@@ -119,7 +121,7 @@ mod tests {
         "CONFIG_FUNCTION_ERROR_INJECTION".to_string(),
         ConfigSetting::Yes,
       );
-      assert!(can_i_use_sleepable_fentry(Some(&configs)));
+      assert!(can_i_use_sleepable_fentry(Some(&configs), None));
     }
 
     #[test]
@@ -129,7 +131,7 @@ mod tests {
         env::remove_var("TRACEXEC_NO_SLEEP");
       }
       let configs = HashMap::new();
-      assert!(!can_i_use_sleepable_fentry(Some(&configs)));
+      assert!(!can_i_use_sleepable_fentry(Some(&configs), None));
     }
 
     #[test]
@@ -138,7 +140,7 @@ mod tests {
       unsafe {
         env::remove_var("TRACEXEC_NO_SLEEP");
       }
-      assert!(can_i_use_sleepable_fentry(None));
+      assert!(can_i_use_sleepable_fentry(None, None));
     }
 
     #[test]
@@ -147,7 +149,7 @@ mod tests {
       unsafe {
         env::set_var("TRACEXEC_NO_SLEEP", "");
       }
-      assert!(can_i_use_sleepable_fentry(None));
+      assert!(can_i_use_sleepable_fentry(None, None));
     }
 
     #[test]
@@ -157,7 +159,7 @@ mod tests {
         env::set_var("TRACEXEC_USE_KPROBE", "1");
         env::remove_var("TRACEXEC_USE_FENTRY");
       }
-      assert!(!kernel_have_ftrace_with_direct_calls(None));
+      assert!(!kernel_have_ftrace_with_direct_calls(None, None));
     }
 
     #[test]
@@ -167,7 +169,7 @@ mod tests {
         env::set_var("TRACEXEC_USE_FENTRY", "1");
         env::remove_var("TRACEXEC_USE_KPROBE");
       }
-      assert!(kernel_have_ftrace_with_direct_calls(None));
+      assert!(kernel_have_ftrace_with_direct_calls(None, None));
     }
 
     #[test]
@@ -182,7 +184,7 @@ mod tests {
         "CONFIG_DYNAMIC_FTRACE_WITH_DIRECT_CALLS".to_string(),
         ConfigSetting::Yes,
       );
-      assert!(kernel_have_ftrace_with_direct_calls(Some(&configs)));
+      assert!(kernel_have_ftrace_with_direct_calls(Some(&configs), None));
     }
   }
 

--- a/crates/tracexec-backend-ebpf/src/tracer.rs
+++ b/crates/tracexec-backend-ebpf/src/tracer.rs
@@ -69,6 +69,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tracexec_core::{
   cli::args::ModifierArgs,
   cmdbuilder::CommandBuilder,
+  elevate,
   event::{
     ExecEvent,
     ExecSyscall,
@@ -159,6 +160,8 @@ pub struct EbpfTracer {
   tx: Option<UnboundedSender<TracerMessage>>,
   filter: BitFlags<TracerEventDetailsKind>,
   mode: TracerMode,
+  tracee_env: Option<elevate::EnvVars>,
+  tracexec_override_env: Option<elevate::EnvVars>,
 }
 
 mod private {
@@ -188,6 +191,8 @@ impl BuildEbpfTracer for TracerBuilder {
         .filter
         .unwrap_or_else(BitFlags::<TracerEventDetailsKind>::all),
       mode: self.mode.unwrap(),
+      tracee_env: self.tracee_env,
+      tracexec_override_env: self.tracexec_override_env,
     }
   }
 }
@@ -587,7 +592,8 @@ impl EbpfTracer {
       .inspect_err(|e| warn!("Failed to get kernel config: {e}"))
       .ok();
     // Check if we should use kprobe on kernels without CONFIG_DYNAMIC_FTRACE_WITH_DIRECT_CALLS
-    if !kernel_have_ftrace_with_direct_calls(kconfig.as_ref()) {
+    let override_env = self.tracexec_override_env.as_deref();
+    if !kernel_have_ftrace_with_direct_calls(kconfig.as_ref(), override_env) {
       open_skel.progs.sys_execve_fentry.set_autoload(false);
       open_skel.progs.sys_execveat_fentry.set_autoload(false);
       open_skel.progs.sys_exit_execve_fexit.set_autoload(false);
@@ -604,7 +610,7 @@ impl EbpfTracer {
         .sys_exit_execveat_kretprobe
         .set_autoload(false);
       // Check if we can use sleepable fentry
-      if can_i_use_sleepable_fentry(kconfig.as_ref()) {
+      if can_i_use_sleepable_fentry(kconfig.as_ref(), override_env) {
         // Can use sleepable fentry :(
         open_skel.progs.sys_execve_fentry.set_flags(BPF_F_SLEEPABLE);
         open_skel
@@ -648,6 +654,9 @@ impl EbpfTracer {
       let mut cmdbuilder = CommandBuilder::new(cmd[0].as_ref());
       cmdbuilder.args(cmd.iter().skip(1));
       cmdbuilder.cwd(std::env::current_dir()?);
+      if let Some(env) = &self.tracee_env {
+        cmdbuilder.envs(env.iter().cloned());
+      }
       let pts = match &self.mode {
         TracerMode::Tui(tty) => tty.as_ref(),
         _ => None,

--- a/crates/tracexec-backend-ptrace/src/ptrace/tracer.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace/tracer.rs
@@ -85,6 +85,7 @@ pub struct Tracer {
   user: Option<User>,
   req_tx: UnboundedSender<PendingRequest>,
   polling_interval: Option<Duration>,
+  tracee_env: Option<tracexec_core::elevate::EnvVars>,
 }
 
 #[derive(Debug, Clone)]
@@ -175,6 +176,7 @@ impl BuildPtraceTracer for TracerBuilder {
             )
           }
         },
+        tracee_env: self.tracee_env,
         mode: self.mode.unwrap(),
       },
       SpawnToken { req_rx, req_tx },

--- a/crates/tracexec-backend-ptrace/src/ptrace/tracer/inner.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace/tracer/inner.rs
@@ -184,6 +184,7 @@ pub struct TracerInner {
   msg_tx: UnboundedSender<TracerMessage>,
   user: Option<User>,
   polling_interval: Option<Duration>,
+  tracee_env: Option<tracexec_core::elevate::EnvVars>,
   breakpoints: Arc<RwLock<BTreeMap<u32, BreakPoint>>>,
   _unsend_marker: PhantomUnsend,
   _unsync_marker: PhantomUnsync,
@@ -222,6 +223,7 @@ impl TracerInner {
       user,
       req_tx: _,
       polling_interval,
+      tracee_env,
     } = tracer;
     printer.init_thread_local(output);
     Ok(Self {
@@ -237,6 +239,7 @@ impl TracerInner {
       msg_tx,
       user,
       polling_interval,
+      tracee_env,
       _unsend_marker: PhantomData,
       _unsync_marker: PhantomData,
     })
@@ -256,6 +259,9 @@ impl TracerInner {
     let mut cmd = CommandBuilder::new(&args[0]);
     cmd.args(args.iter().skip(1));
     cmd.cwd(std::env::current_dir()?);
+    if let Some(env) = &self.tracee_env {
+      cmd.envs(env.iter().cloned());
+    }
 
     let seccomp_bpf = self.seccomp_bpf;
     let slave_pty = match &self.mode {

--- a/crates/tracexec-core/Cargo.toml
+++ b/crates/tracexec-core/Cargo.toml
@@ -45,6 +45,7 @@ clap = { workspace = true }
 crossterm = { workspace = true }
 internment = { version = "0.8.6", default-features = false, features = ["arc", "serde"] }
 tempfile = { workspace = true }
+rand = "0.10"
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/tracexec-core/src/cli.rs
+++ b/crates/tracexec-core/src/cli.rs
@@ -79,9 +79,10 @@ pub struct Cli {
     long,
     hide = true,
     conflicts_with = "elevate",
-    help = "Internal: path to a saved environment file from --elevate"
+    requires = "user",
+    help = "Internal: abstract Unix socket name used to request the original environment from --elevate"
   )]
-  pub restore_env_file: Option<PathBuf>,
+  pub restore_env_socket: Option<String>,
   #[arg(
     long,
     hide = true,
@@ -457,6 +458,20 @@ mod tests {
   }
 
   #[test]
+  fn test_cli_parse_restore_env_socket_requires_user() {
+    let args = vec![
+      "tracexec",
+      "--restore-env-socket",
+      "socket-name",
+      "log",
+      "--",
+      "ls",
+    ];
+    let result = Cli::try_parse_from(args);
+    assert!(result.is_err());
+  }
+
+  #[test]
   fn test_cli_parse_tui_theme_file_cli_source() {
     let args = vec![
       "tracexec",
@@ -512,7 +527,7 @@ mod tests {
       no_profile: false,
       user: None,
       elevate: false,
-      restore_env_file: None,
+      restore_env_socket: None,
       elevated_config_dir: None,
       elevated_data_dir: None,
       elevated_data_local_dir: None,
@@ -571,7 +586,7 @@ mod tests {
       no_profile: false,
       user: None,
       elevate: false,
-      restore_env_file: None,
+      restore_env_socket: None,
       elevated_config_dir: None,
       elevated_data_dir: None,
       elevated_data_local_dir: None,
@@ -635,7 +650,7 @@ mod tests {
       no_profile: false,
       user: None,
       elevate: false,
-      restore_env_file: None,
+      restore_env_socket: None,
       elevated_config_dir: None,
       elevated_data_dir: None,
       elevated_data_local_dir: None,

--- a/crates/tracexec-core/src/cmdbuilder.rs
+++ b/crates/tracexec-core/src/cmdbuilder.rs
@@ -90,6 +90,7 @@ fn get_shell() -> String {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CommandBuilder {
   args: Vec<OsString>,
+  env: Option<Vec<(OsString, OsString)>>,
   cwd: Option<PathBuf>,
   pub(crate) umask: Option<libc::mode_t>,
   controlling_tty: bool,
@@ -101,6 +102,7 @@ impl CommandBuilder {
   pub fn new<S: AsRef<OsStr>>(program: S) -> Self {
     Self {
       args: vec![program.as_ref().to_owned()],
+      env: None,
       cwd: None,
       umask: None,
       controlling_tty: true,
@@ -111,6 +113,7 @@ impl CommandBuilder {
   pub fn from_argv(args: Vec<OsString>) -> Self {
     Self {
       args,
+      env: None,
       cwd: None,
       umask: None,
       controlling_tty: true,
@@ -136,6 +139,7 @@ impl CommandBuilder {
   pub fn new_default_prog() -> Self {
     Self {
       args: vec![],
+      env: None,
       cwd: None,
       umask: None,
       controlling_tty: true,
@@ -175,6 +179,35 @@ impl CommandBuilder {
     &mut self.args
   }
 
+  pub fn env<K, V>(&mut self, key: K, value: V)
+  where
+    K: AsRef<OsStr>,
+    V: AsRef<OsStr>,
+  {
+    self
+      .env
+      .get_or_insert_with(Vec::new)
+      .push((key.as_ref().to_owned(), value.as_ref().to_owned()));
+  }
+
+  pub fn envs<I, K, V>(&mut self, envs: I)
+  where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<OsString>,
+    V: Into<OsString>,
+  {
+    self.env = Some(
+      envs
+        .into_iter()
+        .map(|(key, value)| (key.into(), value.into()))
+        .collect(),
+    );
+  }
+
+  pub fn get_env(&self) -> Option<&[(OsString, OsString)]> {
+    self.env.as_deref()
+  }
+
   pub fn cwd<D>(&mut self, dir: D)
   where
     D: AsRef<Path>,
@@ -197,7 +230,13 @@ impl CommandBuilder {
   }
 
   fn resolve_path(&self) -> Option<OsString> {
-    env::var_os("PATH")
+    match &self.env {
+      Some(env) => env
+        .iter()
+        .rev()
+        .find_map(|(key, value)| (key == OsStr::new("PATH")).then_some(value.clone())),
+      None => env::var_os("PATH"),
+    }
   }
 
   fn search_path(&self, exe: &OsStr, cwd: &Path) -> color_eyre::Result<PathBuf> {
@@ -243,7 +282,6 @@ impl CommandBuilder {
 
   /// Convert the CommandBuilder to a `Command` instance.
   pub(crate) fn build(self) -> color_eyre::Result<Command> {
-    use std::os::unix::process::CommandExt;
     let cwd = env::current_dir()?;
     let dir = if let Some(dir) = self.cwd.as_deref() {
       dir.to_owned()
@@ -260,6 +298,20 @@ impl CommandBuilder {
         .into_iter()
         .map(|a| CString::new(a.into_vec()))
         .collect::<Result<_, _>>()?,
+      env: self
+        .env
+        .map(|env| {
+          env
+            .into_iter()
+            .map(|(key, value)| {
+              let mut bytes = key.into_vec();
+              bytes.push(b'=');
+              bytes.extend_from_slice(&value.into_vec());
+              CString::new(bytes)
+            })
+            .collect::<Result<Vec<_>, _>>()
+        })
+        .transpose()?,
       cwd: dir,
     })
   }
@@ -268,6 +320,7 @@ impl CommandBuilder {
 pub struct Command {
   pub program: PathBuf,
   pub args: Vec<CString>,
+  pub env: Option<Vec<CString>>,
   pub cwd: PathBuf,
 }
 
@@ -420,6 +473,38 @@ mod tests {
       let args: Vec<&str> = cmd.args.iter().map(|c| c.to_str().unwrap()).collect();
 
       assert_eq!(args, ["echo", "hello"]);
+      assert!(cmd.env.is_none());
+      dir.close().unwrap()
+    }
+
+    #[test]
+    fn test_build_sets_explicit_env() {
+      let dir = TempDir::new().unwrap();
+      let exe = make_executable(&dir, "cmd");
+
+      let mut b = CommandBuilder::new("cmd");
+      b.envs([
+        (OsString::from("PATH"), dir.path().as_os_str().to_owned()),
+        (OsString::from("TRACEXEC_TEST"), OsString::from("value")),
+      ]);
+
+      let cmd = b.build().unwrap();
+
+      assert_eq!(cmd.program, exe);
+      let env: Vec<String> = cmd
+        .env
+        .as_ref()
+        .unwrap()
+        .iter()
+        .map(|c| c.to_str().unwrap().to_owned())
+        .collect();
+      assert_eq!(
+        env,
+        vec![
+          "PATH=".to_string() + dir.path().to_str().unwrap(),
+          "TRACEXEC_TEST=value".to_string(),
+        ]
+      );
       dir.close().unwrap()
     }
 

--- a/crates/tracexec-core/src/elevate.rs
+++ b/crates/tracexec-core/src/elevate.rs
@@ -1,44 +1,93 @@
 //! Privilege elevation support for tracexec.
 //!
-//! When `--elevate` is used, tracexec captures the current user's credentials
-//! and environment variables, saves them to a secure temporary file, then
-//! re-executes itself with elevated privileges via `sudo`. The elevated process
-//! restores the original environment from the file and passes `--user <username>`
-//! so the tracee runs as the original user.
-//!
-//! ## Security
-//!
-//! The environment file is created with mode 0600 and owned by the current user.
-//! On restore, the file is opened with `O_NOFOLLOW` (rejecting symlinks), its
-//! metadata is checked via `fstat` (avoiding TOCTOU races), and it is unlinked
-//! immediately after reading. Only the original user and root can access it.
+//! When `--elevate` is used, tracexec captures the current user's credentials,
+//! creates a private abstract Unix domain socket, and spawns `sudo tracexec`.
+//! The elevated child requests the complete original environment over that
+//! socket. The unelevated parent verifies the child's Unix socket credentials
+//! before sending anything, then waits for the elevated child to exit. The
+//! elevated tracexec process may only consult an allowlisted subset for its own
+//! behavior, while the tracee is spawned with the complete original environment.
 
 use std::{
-  ffi::OsString,
-  fs,
+  collections::HashSet,
+  ffi::{
+    OsStr,
+    OsString,
+  },
   io::{
+    ErrorKind,
     Read,
     Write,
   },
-  os::unix::{
-    ffi::OsStrExt,
-    fs::OpenOptionsExt,
+  os::{
+    linux::net::SocketAddrExt,
+    unix::{
+      ffi::{
+        OsStrExt,
+        OsStringExt,
+      },
+      net::{
+        SocketAddr,
+        UnixListener,
+        UnixStream,
+      },
+      process::ExitStatusExt,
+    },
   },
   path::Path,
-  process::Command,
+  process::{
+    Child,
+    Command,
+    ExitStatus,
+  },
+  sync::LazyLock,
+  time::{
+    Duration,
+    Instant,
+  },
 };
 
+use color_eyre::eyre::bail;
 use nix::{
-  fcntl::OFlag,
-  sys::stat::{
-    self,
-    SFlag,
+  sys::socket::{
+    getsockopt,
+    sockopt,
   },
   unistd::{
     Uid,
     User,
   },
 };
+use rand::distr::{
+  Alphanumeric,
+  SampleString,
+};
+
+pub type EnvVars = Vec<(OsString, OsString)>;
+
+const ENV_REQUEST_MAGIC: &[u8] = b"tracexec-env-v1";
+const ENV_SOCKET_ACCEPT_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Environment variables elevated tracexec may consult after `--elevate`.
+///
+/// Keep this list limited to variables that tracexec itself reads. The complete
+/// original environment is transferred as data, but only these keys are exposed
+/// to elevated tracexec behavior. The tracee still receives the complete
+/// original environment at `execve(2)`.
+///
+/// `TRACEXEC_DATA` is passed via cmdline and thus not allowed here.
+/// Variables only for development, like `TRACEXEC_BPFCOV_OUTDIR`,
+/// are also not allowed.
+pub static RESTORED_ENV_ALLOWLIST: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
+  HashSet::from([
+    "NO_COLOR",
+    "RUST_LOG",
+    "TRACEXEC_LOG_LEVEL",
+    "TRACEXEC_NO_SLEEP",
+    "TRACEXEC_USE_FENTRY",
+    "TRACEXEC_USE_KPROBE",
+  ])
+});
 
 /// Saved credentials from before privilege elevation.
 #[derive(Debug, Clone)]
@@ -63,12 +112,55 @@ impl PreElevationCreds {
   }
 }
 
-/// Serialize all current environment variables into a byte buffer.
+pub fn env_value<'a>(env: &'a [(OsString, OsString)], key: &str) -> Option<&'a OsStr> {
+  let key = OsStr::new(key);
+  env
+    .iter()
+    .rev()
+    .find_map(|(candidate, value)| (candidate == key).then_some(value.as_os_str()))
+}
+
+pub fn env_var_os(env: Option<&[(OsString, OsString)]>, key: &str) -> Option<OsString> {
+  match env {
+    Some(env) => env_value(env, key).map(OsStr::to_owned),
+    None => std::env::var_os(key),
+  }
+}
+
+pub fn env_var_string(env: Option<&[(OsString, OsString)]>, key: &str) -> Option<String> {
+  match env {
+    Some(env) => env_value(env, key).map(|value| value.to_string_lossy().into_owned()),
+    None => std::env::var(key).ok(),
+  }
+}
+
+pub fn filter_allowlisted_env_from(
+  vars: impl IntoIterator<Item = (OsString, OsString)>,
+) -> EnvVars {
+  vars
+    .into_iter()
+    .filter(|(key, _)| {
+      key
+        .to_str()
+        .is_some_and(|key| RESTORED_ENV_ALLOWLIST.contains(key))
+    })
+    .collect()
+}
+
+pub fn filter_allowlisted_env(env: &[(OsString, OsString)]) -> EnvVars {
+  filter_allowlisted_env_from(env.iter().cloned())
+}
+
+fn collect_original_env() -> EnvVars {
+  std::env::vars_os().collect()
+}
+
+/// Serialize environment variables into a byte buffer.
 ///
-/// Uses the null-byte-separated `KEY=VALUE\0` format (same as `/proc/self/environ`).
-fn serialize_env() -> Vec<u8> {
+/// Uses the null-byte-separated `KEY=VALUE\0` format.
+fn serialize_env(env: &[(OsString, OsString)]) -> Vec<u8> {
   let mut buf = Vec::new();
-  for (key, value) in std::env::vars_os() {
+  for (key, value) in env {
     buf.extend_from_slice(key.as_bytes());
     buf.push(b'=');
     buf.extend_from_slice(value.as_bytes());
@@ -78,8 +170,7 @@ fn serialize_env() -> Vec<u8> {
 }
 
 /// Deserialize environment variables from null-byte-separated `KEY=VALUE\0` format.
-fn deserialize_env(data: &[u8]) -> Vec<(OsString, OsString)> {
-  use std::os::unix::ffi::OsStringExt;
+fn deserialize_env(data: &[u8]) -> EnvVars {
   let mut result = Vec::new();
   for entry in data.split(|&b| b == 0) {
     if entry.is_empty() {
@@ -94,80 +185,96 @@ fn deserialize_env(data: &[u8]) -> Vec<(OsString, OsString)> {
   result
 }
 
-/// Save the current environment to a temporary file with secure permissions.
-///
-/// Returns the path to the file. The file is created with mode 0600.
-fn save_env_to_file() -> color_eyre::Result<std::path::PathBuf> {
-  let dir = std::env::temp_dir();
-  let env_data = serialize_env();
-
-  // Create tempfile with a unique path, then write data to it.
-  // tempfile creates with mode 0600 by default on Unix.
-  let mut tmpfile = tempfile::Builder::new()
-    .prefix("tracexec-env-")
-    .tempfile_in(&dir)?;
-  tmpfile.write_all(&env_data)?;
-  tmpfile.flush()?;
-
-  // Persist so the file survives after we exec into sudo.
-  let path = tmpfile.into_temp_path().keep()?;
-  Ok(path)
+fn abstract_socket_addr(socket_name: &str) -> color_eyre::Result<SocketAddr> {
+  Ok(SocketAddr::from_abstract_name(socket_name.as_bytes())?)
 }
 
-/// Restore environment variables from a saved env file.
-///
-/// Security checks performed:
-/// - File is opened with `O_NOFOLLOW` to reject symlinks
-/// - `fstat` is used on the open fd to verify:
-///   - File is a regular file
-/// - File is unlinked immediately after reading
-pub fn restore_env_from_file(path: &Path) -> color_eyre::Result<()> {
-  // Open with O_NOFOLLOW to reject symlinks
-  let file = fs::OpenOptions::new()
-    .read(true)
-    .custom_flags(OFlag::O_NOFOLLOW.bits())
-    .open(path)
-    .map_err(|e| color_eyre::eyre::eyre!("Failed to open env file {}: {e}", path.display()))?;
+fn random_socket_name() -> String {
+  let suffix = Alphanumeric.sample_string(&mut rand::rng(), 32);
+  format!("tracexec-env-{}-{suffix}", std::process::id())
+}
 
-  let fd_stat = stat::fstat(&file)?;
+fn bind_env_socket(socket_name: &str) -> color_eyre::Result<UnixListener> {
+  Ok(UnixListener::bind_addr(&abstract_socket_addr(
+    socket_name,
+  )?)?)
+}
 
-  // Verify it's a regular file
-  let file_type = SFlag::from_bits_truncate(fd_stat.st_mode & SFlag::S_IFMT.bits());
-  if file_type != SFlag::S_IFREG {
-    color_eyre::eyre::bail!(
-      "Env file {} is not a regular file (mode={:#o})",
-      path.display(),
-      fd_stat.st_mode
+fn exit_code_from_status(status: ExitStatus) -> i32 {
+  status
+    .code()
+    .or_else(|| status.signal().map(|signal| 128 + signal))
+    .unwrap_or(1)
+}
+
+fn handle_env_request(
+  mut stream: UnixStream,
+  env: &[(OsString, OsString)],
+  required_uid: u32,
+) -> color_eyre::Result<()> {
+  let creds = getsockopt(&stream, sockopt::PeerCredentials)?;
+  if creds.uid() != required_uid {
+    bail!(
+      "Refusing to send environment variables to uid {} (expected uid {required_uid})",
+      creds.uid()
     );
   }
 
-  // Read the file contents
-  let mut data = Vec::new();
-  let mut file = file;
-  file.read_to_end(&mut data)?;
-
-  // Unlink immediately after reading
-  if let Err(e) = fs::remove_file(path) {
-    tracing::warn!("Failed to remove env file {}: {e}", path.display());
+  let mut request = vec![0; ENV_REQUEST_MAGIC.len()];
+  stream.read_exact(&mut request)?;
+  if request != ENV_REQUEST_MAGIC {
+    bail!("Invalid request");
   }
 
-  // Deserialize and restore
-  let saved_env = deserialize_env(&data);
-
-  // SAFETY: restore_env_from_file is called early in main.
-  unsafe {
-    // Clear all current env vars
-    for (key, _) in std::env::vars_os() {
-      std::env::remove_var(&key);
-    }
-
-    // Set the saved env vars
-    for (key, value) in saved_env {
-      std::env::set_var(key, value);
-    }
-  }
-
+  let payload = serialize_env(env);
+  stream.write_all(&(payload.len() as u32).to_be_bytes())?;
+  stream.write_all(&payload)?;
+  stream.flush()?;
   Ok(())
+}
+
+fn serve_env_to_child(
+  listener: &UnixListener,
+  child: &mut Child,
+  env: &[(OsString, OsString)],
+  timeout: Duration,
+) -> color_eyre::Result<Option<ExitStatus>> {
+  listener.set_nonblocking(true)?;
+  let deadline = Instant::now() + timeout;
+
+  loop {
+    if let Some(status) = child.try_wait()? {
+      return Ok(Some(status));
+    }
+
+    match listener.accept() {
+      Ok((stream, _)) => {
+        handle_env_request(stream, env, 0)?;
+        return Ok(None);
+      }
+      Err(e) if e.kind() == ErrorKind::WouldBlock => {
+        if Instant::now() >= deadline {
+          bail!("Timed out waiting for the elevated subprocess to request environment variables");
+        }
+        std::thread::sleep(Duration::from_millis(50));
+      }
+      Err(e) => return Err(e.into()),
+    }
+  }
+}
+
+/// Request the complete original environment from the unelevated parent.
+pub fn request_env_from_parent(socket_name: &str) -> color_eyre::Result<EnvVars> {
+  let mut stream = UnixStream::connect_addr(&abstract_socket_addr(socket_name)?)?;
+  stream.write_all(ENV_REQUEST_MAGIC)?;
+  stream.flush()?;
+
+  let mut len = [0; 4];
+  stream.read_exact(&mut len)?;
+  let len = u32::from_be_bytes(len) as usize;
+  let mut payload = vec![0; len];
+  stream.read_exact(&mut payload)?;
+  Ok(deserialize_env(&payload))
 }
 
 /// Construct the command line for re-execution with elevation.
@@ -176,14 +283,14 @@ pub fn restore_env_from_file(path: &Path) -> color_eyre::Result<()> {
 /// into
 ///
 /// ```bash
-/// sudo tracexec --user <username> --restore-env-file <path> \
+/// sudo tracexec --user <username> --restore-env-socket <socket-name> \
 ///   --elevated-config-dir <path> --elevated-data-dir <path> \
 ///   --elevated-data-local-dir <path> [opts] <subcommand> [args] \
 ///   -- <cmd...>
 /// ```
 fn build_elevated_args(
   creds: &PreElevationCreds,
-  env_file: &Path,
+  socket_name: &str,
   config_dir: Option<&Path>,
   data_dir: Option<&Path>,
   data_local_dir: Option<&Path>,
@@ -191,7 +298,7 @@ fn build_elevated_args(
   build_elevated_args_from(
     std::env::args_os(),
     creds,
-    env_file,
+    socket_name,
     config_dir,
     data_dir,
     data_local_dir,
@@ -204,7 +311,7 @@ fn build_elevated_args(
 fn build_elevated_args_from(
   args: impl IntoIterator<Item = impl Into<OsString>>,
   creds: &PreElevationCreds,
-  env_file: &Path,
+  socket_name: &str,
   config_dir: Option<&Path>,
   data_dir: Option<&Path>,
   data_local_dir: Option<&Path>,
@@ -226,12 +333,12 @@ fn build_elevated_args_from(
       continue;
     }
     if !replaced && arg == "--elevate" {
-      // Replace the first --elevate with --user/--restore-env-file and optional dir overrides.
+      // Replace the first --elevate with --user/--restore-env-socket and optional dir overrides.
       replaced = true;
       result.push(OsString::from("--user"));
       result.push(OsString::from(&creds.username));
-      result.push(OsString::from("--restore-env-file"));
-      result.push(env_file.as_os_str().to_owned());
+      result.push(OsString::from("--restore-env-socket"));
+      result.push(OsString::from(socket_name));
       if let Some(dir) = config_dir {
         result.push(OsString::from("--elevated-config-dir"));
         result.push(dir.as_os_str().to_owned());
@@ -254,20 +361,17 @@ fn build_elevated_args_from(
 
 /// Re-execute tracexec with elevated privileges via sudo.
 ///
-/// This function:
-/// 1. Saves the current environment to a secure temp file
-/// 2. Re-execs via `sudo` (without `-E`) with `--user <username>` and `--restore-env-file <path>`
-///
-/// This function does not return on success (it replaces the current process).
+/// This function does not return on success: the unelevated parent exits with
+/// the same status as the elevated child.
 pub fn elevate_and_reexec() -> color_eyre::Result<std::convert::Infallible> {
-  use std::os::unix::process::CommandExt;
-
   if Uid::effective().is_root() {
     color_eyre::eyre::bail!("--elevate is not needed when already running as root");
   }
 
   let creds = PreElevationCreds::capture()?;
-  let env_file = save_env_to_file()?;
+  let socket_name = random_socket_name();
+  let listener = bind_env_socket(&socket_name)?;
+  let env = collect_original_env();
   let exe = std::env::current_exe()?;
 
   // Capture the current user's project directories so the elevated process
@@ -278,7 +382,7 @@ pub fn elevate_and_reexec() -> color_eyre::Result<std::convert::Infallible> {
   let data_local_dir = proj_dirs.as_ref().map(|d| d.data_local_dir().to_path_buf());
   let elevated_args = build_elevated_args(
     &creds,
-    &env_file,
+    &socket_name,
     config_dir.as_deref(),
     data_dir.as_deref(),
     data_local_dir.as_deref(),
@@ -294,18 +398,41 @@ pub fn elevate_and_reexec() -> color_eyre::Result<std::convert::Infallible> {
       .join(" ")
   );
 
-  let err = Command::new("sudo").arg(&exe).args(&elevated_args).exec();
-
-  // exec() only returns on error — clean up the env file
-  let _ = fs::remove_file(&env_file);
-  Err(err.into())
+  let mut child = Command::new("sudo")
+    .arg(&exe)
+    .args(&elevated_args)
+    .spawn()?;
+  match serve_env_to_child(&listener, &mut child, &env, ENV_SOCKET_ACCEPT_TIMEOUT) {
+    Ok(Some(status)) => std::process::exit(exit_code_from_status(status)),
+    Ok(None) => {
+      drop(listener);
+      let status = child.wait()?;
+      std::process::exit(exit_code_from_status(status));
+    }
+    Err(e) => {
+      let _ = child.kill();
+      let _ = child.wait();
+      Err(e)
+    }
+  }
 }
 
 #[cfg(test)]
 mod tests {
-  use std::os::unix::ffi::OsStringExt;
+  use std::{
+    os::unix::ffi::OsStringExt,
+    thread,
+  };
 
   use super::*;
+
+  fn test_creds() -> PreElevationCreds {
+    PreElevationCreds {
+      username: "testuser".to_string(),
+      uid: 1000,
+      gid: 1000,
+    }
+  }
 
   #[test]
   fn test_capture_creds() {
@@ -316,45 +443,34 @@ mod tests {
   }
 
   #[test]
+  fn test_allowlist_filters_unneeded_env_vars() {
+    let filtered = filter_allowlisted_env_from([
+      (OsString::from("TRACEXEC_NO_SLEEP"), OsString::from("1")),
+      (
+        OsString::from("TRACEXEC_TEST_MARKER"),
+        OsString::from("secret"),
+      ),
+      (OsString::from("PATH"), OsString::from("/usr/bin")),
+    ]);
+
+    assert_eq!(
+      filtered,
+      vec![(OsString::from("TRACEXEC_NO_SLEEP"), OsString::from("1"),),]
+    );
+  }
+
+  #[test]
   fn test_serialize_deserialize_roundtrip() {
     let original = vec![
-      (OsString::from("HOME"), OsString::from("/home/test")),
+      (OsString::from("TRACEXEC_NO_SLEEP"), OsString::from("1")),
       (OsString::from("PATH"), OsString::from("/usr/bin:/bin")),
       (OsString::from("EMPTY"), OsString::from("")),
       (OsString::from("MULTI_EQ"), OsString::from("a=b=c")),
     ];
 
-    let mut buf = Vec::new();
-    for (k, v) in &original {
-      buf.extend_from_slice(k.as_bytes());
-      buf.push(b'=');
-      buf.extend_from_slice(v.as_bytes());
-      buf.push(0);
-    }
-
-    let deserialized = deserialize_env(&buf);
+    let data = serialize_env(&original);
+    let deserialized = deserialize_env(&data);
     assert_eq!(deserialized, original);
-  }
-
-  #[test]
-  fn test_serialize_env_format() {
-    // serialize_env reads from the real env, just verify it produces null-terminated entries
-    let data = serialize_env();
-    if data.is_empty() {
-      return; // unlikely in a real test env
-    }
-    // Should end with a null byte (last entry's terminator)
-    assert_eq!(*data.last().unwrap(), 0u8);
-    // Every non-empty entry should contain '='
-    for entry in data.split(|&b| b == 0) {
-      if !entry.is_empty() {
-        assert!(
-          entry.contains(&b'='),
-          "entry missing '=': {:?}",
-          String::from_utf8_lossy(entry)
-        );
-      }
-    }
   }
 
   #[test]
@@ -386,102 +502,29 @@ mod tests {
   }
 
   #[test]
-  fn test_save_env_file() {
-    let env_file = save_env_to_file().unwrap();
+  fn test_env_socket_roundtrip() {
+    let socket_name = random_socket_name();
+    let listener = bind_env_socket(&socket_name).unwrap();
+    let env = vec![
+      (OsString::from("TRACEXEC_NO_SLEEP"), OsString::from("1")),
+      (OsString::from("PATH"), OsString::from("/usr/bin")),
+    ];
+    let expected = env.clone();
+    let uid = nix::unistd::getuid().as_raw();
 
-    // Verify the file exists and has correct permissions
-    let metadata = fs::metadata(&env_file).unwrap();
-    use std::os::unix::fs::MetadataExt;
-    assert_eq!(metadata.mode() & 0o7777, 0o600);
-    assert_eq!(metadata.uid(), nix::unistd::getuid().as_raw());
+    let server = thread::spawn(move || {
+      let (stream, _) = listener.accept().unwrap();
+      handle_env_request(stream, &env, uid).unwrap();
+    });
 
-    // Clean up: remove the file ourselves since we're not actually restoring
-    fs::remove_file(&env_file).unwrap();
-  }
-
-  #[test]
-  fn test_restore_env_rejects_symlink() {
-    let env_file = save_env_to_file().unwrap();
-    let symlink_path = env_file.with_extension("link");
-    std::os::unix::fs::symlink(&env_file, &symlink_path).unwrap();
-
-    // Opening a symlink with O_NOFOLLOW should fail
-    let result = restore_env_from_file(&symlink_path);
-    assert!(result.is_err());
-
-    let _ = fs::remove_file(&symlink_path);
-    let _ = fs::remove_file(&env_file);
-  }
-
-  #[test]
-  fn test_restore_env_preserves_values_in_subprocess() {
-    // We test that save + restore correctly round-trips by writing known values,
-    // saving, then restoring with the correct uid.
-    use std::os::unix::fs::PermissionsExt;
-
-    // Create a temp file with known env content
-    let dir = std::env::temp_dir();
-    let mut tmpfile = tempfile::Builder::new()
-      .prefix("tracexec-env-test-")
-      .tempfile_in(&dir)
-      .unwrap();
-
-    let test_env = b"TEST_RESTORE_A=hello_world\0TEST_RESTORE_B=foo=bar=baz\0TEST_RESTORE_C=\0";
-    tmpfile.write_all(test_env).unwrap();
-    tmpfile.flush().unwrap();
-    let path = tmpfile.into_temp_path().keep().unwrap();
-
-    // Verify permissions are 0600
-    let meta = fs::metadata(&path).unwrap();
-    assert_eq!(meta.permissions().mode() & 0o7777, 0o600);
-
-    let my_uid = nix::unistd::getuid().as_raw();
-
-    // We can't easily test the full env restoration in-process (it would
-    // clobber the test runner's env). Instead, verify the file passes
-    // all security checks by reading it manually the same way restore does.
-    let file = fs::OpenOptions::new()
-      .read(true)
-      .custom_flags(OFlag::O_NOFOLLOW.bits())
-      .open(&path)
-      .unwrap();
-    let fd_stat = stat::fstat(&file).unwrap();
-    assert_eq!(fd_stat.st_uid, my_uid);
-    assert_eq!(fd_stat.st_mode & 0o7777, 0o600);
-
-    let mut data = Vec::new();
-    let mut file = file;
-    file.read_to_end(&mut data).unwrap();
-    let restored = deserialize_env(&data);
-    assert_eq!(
-      restored,
-      vec![
-        (
-          OsString::from("TEST_RESTORE_A"),
-          OsString::from("hello_world")
-        ),
-        (
-          OsString::from("TEST_RESTORE_B"),
-          OsString::from("foo=bar=baz")
-        ),
-        (OsString::from("TEST_RESTORE_C"), OsString::from("")),
-      ]
-    );
-
-    let _ = fs::remove_file(&path);
+    let received = request_env_from_parent(&socket_name).unwrap();
+    server.join().unwrap();
+    assert_eq!(received, expected);
   }
 
   #[test]
   fn test_build_elevated_args_replaces_elevate() {
-    let creds = PreElevationCreds {
-      username: "testuser".to_string(),
-      uid: 1000,
-      gid: 1000,
-    };
-
-    let env_path = Path::new("/tmp/tracexec-env-abc123");
-
-    // Simulate: tracexec --elevate tui -t -- sudo ls
+    let creds = test_creds();
     let input_args = vec![
       OsString::from("tracexec"),
       OsString::from("--elevate"),
@@ -492,59 +535,20 @@ mod tests {
       OsString::from("ls"),
     ];
 
-    let result = build_elevated_args_from(input_args, &creds, env_path, None, None, None);
+    let result = build_elevated_args_from(input_args, &creds, "sock-name", None, None, None);
 
     assert_eq!(
       result,
       vec![
         OsString::from("--user"),
         OsString::from("testuser"),
-        OsString::from("--restore-env-file"),
-        OsString::from("/tmp/tracexec-env-abc123"),
+        OsString::from("--restore-env-socket"),
+        OsString::from("sock-name"),
         OsString::from("tui"),
         OsString::from("-t"),
         OsString::from("--"),
         OsString::from("sudo"),
         OsString::from("ls"),
-      ]
-    );
-  }
-
-  #[test]
-  fn test_build_elevated_args_with_ebpf() {
-    let creds = PreElevationCreds {
-      username: "alice".to_string(),
-      uid: 1001,
-      gid: 100,
-    };
-
-    let env_path = Path::new("/tmp/tracexec-env-xyz");
-
-    // Simulate: tracexec --elevate ebpf tui -t -- bash
-    let input_args = vec![
-      OsString::from("tracexec"),
-      OsString::from("--elevate"),
-      OsString::from("ebpf"),
-      OsString::from("tui"),
-      OsString::from("-t"),
-      OsString::from("--"),
-      OsString::from("bash"),
-    ];
-
-    let result = build_elevated_args_from(input_args, &creds, env_path, None, None, None);
-
-    assert_eq!(
-      result,
-      vec![
-        OsString::from("--user"),
-        OsString::from("alice"),
-        OsString::from("--restore-env-file"),
-        OsString::from("/tmp/tracexec-env-xyz"),
-        OsString::from("ebpf"),
-        OsString::from("tui"),
-        OsString::from("-t"),
-        OsString::from("--"),
-        OsString::from("bash"),
       ]
     );
   }
@@ -556,10 +560,6 @@ mod tests {
       uid: 1002,
       gid: 1002,
     };
-
-    let env_path = Path::new("/tmp/tracexec-env-999");
-
-    // Simulate: tracexec --color=always --elevate -C /tmp log -- ls
     let input_args = vec![
       OsString::from("tracexec"),
       OsString::from("--color=always"),
@@ -571,7 +571,7 @@ mod tests {
       OsString::from("ls"),
     ];
 
-    let result = build_elevated_args_from(input_args, &creds, env_path, None, None, None);
+    let result = build_elevated_args_from(input_args, &creds, "sock-999", None, None, None);
 
     assert_eq!(
       result,
@@ -579,8 +579,8 @@ mod tests {
         OsString::from("--color=always"),
         OsString::from("--user"),
         OsString::from("bob"),
-        OsString::from("--restore-env-file"),
-        OsString::from("/tmp/tracexec-env-999"),
+        OsString::from("--restore-env-socket"),
+        OsString::from("sock-999"),
         OsString::from("-C"),
         OsString::from("/tmp"),
         OsString::from("log"),
@@ -592,13 +592,7 @@ mod tests {
 
   #[test]
   fn test_build_elevated_args_passes_project_dirs() {
-    let creds = PreElevationCreds {
-      username: "testuser".to_string(),
-      uid: 1000,
-      gid: 1000,
-    };
-
-    let env_path = Path::new("/tmp/tracexec-env-abc123");
+    let creds = test_creds();
     let config_dir = Path::new("/home/testuser/.config/tracexec");
     let data_dir = Path::new("/home/testuser/.local/share/tracexec");
     let data_local_dir = Path::new("/home/testuser/.local/share/tracexec");
@@ -614,7 +608,7 @@ mod tests {
     let result = build_elevated_args_from(
       input_args,
       &creds,
-      env_path,
+      "sock-abc",
       Some(config_dir),
       Some(data_dir),
       Some(data_local_dir),
@@ -625,8 +619,8 @@ mod tests {
       vec![
         OsString::from("--user"),
         OsString::from("testuser"),
-        OsString::from("--restore-env-file"),
-        OsString::from("/tmp/tracexec-env-abc123"),
+        OsString::from("--restore-env-socket"),
+        OsString::from("sock-abc"),
         OsString::from("--elevated-config-dir"),
         OsString::from("/home/testuser/.config/tracexec"),
         OsString::from("--elevated-data-dir"),
@@ -642,16 +636,7 @@ mod tests {
 
   #[test]
   fn test_build_elevated_args_ignores_elevate_after_delimiter() {
-    let creds = PreElevationCreds {
-      username: "testuser".to_string(),
-      uid: 1000,
-      gid: 1000,
-    };
-
-    let env_path = Path::new("/tmp/tracexec-env-abc123");
-
-    // Simulate: tracexec --elevate log -- cmd --elevate
-    // The --elevate after -- should NOT be replaced.
+    let creds = test_creds();
     let input_args = vec![
       OsString::from("tracexec"),
       OsString::from("--elevate"),
@@ -661,15 +646,15 @@ mod tests {
       OsString::from("--elevate"),
     ];
 
-    let result = build_elevated_args_from(input_args, &creds, env_path, None, None, None);
+    let result = build_elevated_args_from(input_args, &creds, "sock-abc", None, None, None);
 
     assert_eq!(
       result,
       vec![
         OsString::from("--user"),
         OsString::from("testuser"),
-        OsString::from("--restore-env-file"),
-        OsString::from("/tmp/tracexec-env-abc123"),
+        OsString::from("--restore-env-socket"),
+        OsString::from("sock-abc"),
         OsString::from("log"),
         OsString::from("--"),
         OsString::from("cmd"),

--- a/crates/tracexec-core/src/proc.rs
+++ b/crates/tracexec-core/src/proc.rs
@@ -8,7 +8,10 @@ use std::{
     BTreeSet,
     HashSet,
   },
-  ffi::CString,
+  ffi::{
+    CString,
+    OsString,
+  },
   fmt::{
     Display,
     Formatter,
@@ -721,30 +724,59 @@ pub struct BaselineInfo {
 }
 
 impl BaselineInfo {
-  pub fn new() -> color_eyre::Result<Self> {
-    let cwd = cached_str(&std::env::current_dir()?.to_string_lossy()).into();
-    let env = std::env::vars()
+  fn env_from_vars_os(
+    vars: impl IntoIterator<Item = (OsString, OsString)>,
+  ) -> BTreeMap<OutputMsg, OutputMsg> {
+    vars
+      .into_iter()
       .map(|(k, v)| {
         (
-          CACHE.get_or_insert_owned(k).into(),
-          CACHE.get_or_insert_owned(v).into(),
+          CACHE
+            .get_or_insert_owned(k.to_string_lossy().into_owned())
+            .into(),
+          CACHE
+            .get_or_insert_owned(v.to_string_lossy().into_owned())
+            .into(),
         )
       })
-      .collect();
+      .collect()
+  }
+
+  fn env_from_override(env: Option<&[(OsString, OsString)]>) -> BTreeMap<OutputMsg, OutputMsg> {
+    match env {
+      Some(env) => Self::env_from_vars_os(env.iter().cloned()),
+      None => std::env::vars()
+        .map(|(k, v)| {
+          (
+            CACHE.get_or_insert_owned(k).into(),
+            CACHE.get_or_insert_owned(v).into(),
+          )
+        })
+        .collect(),
+    }
+  }
+
+  pub fn new() -> color_eyre::Result<Self> {
+    Self::new_with_env(None)
+  }
+
+  pub fn new_with_env(env: Option<&[(OsString, OsString)]>) -> color_eyre::Result<Self> {
+    let cwd = cached_str(&std::env::current_dir()?.to_string_lossy()).into();
+    let env = Self::env_from_override(env);
     let fdinfo = FileDescriptorInfoCollection::new_baseline()?;
     Ok(Self { cwd, env, fdinfo })
   }
 
   pub fn with_pts(pts: &UnixSlavePty) -> color_eyre::Result<Self> {
+    Self::with_pts_and_env(pts, None)
+  }
+
+  pub fn with_pts_and_env(
+    pts: &UnixSlavePty,
+    env: Option<&[(OsString, OsString)]>,
+  ) -> color_eyre::Result<Self> {
     let cwd = cached_str(&std::env::current_dir()?.to_string_lossy()).into();
-    let env = std::env::vars()
-      .map(|(k, v)| {
-        (
-          CACHE.get_or_insert_owned(k).into(),
-          CACHE.get_or_insert_owned(v).into(),
-        )
-      })
-      .collect();
+    let env = Self::env_from_override(env);
     let fdinfo = FileDescriptorInfoCollection::with_pts(pts)?;
     Ok(Self { cwd, env, fdinfo })
   }

--- a/crates/tracexec-core/src/pty.rs
+++ b/crates/tracexec-core/src/pty.rs
@@ -82,6 +82,7 @@ use nix::{
     Pid,
     dup2,
     execv,
+    execve,
     fork,
   },
 };
@@ -641,11 +642,12 @@ fn spawn_command_from_pty_fd(
         _ = unsafe { libc::umask(mask) };
       }
 
-      execv(
-        &CString::new(cmd.program.into_os_string().into_vec()).unwrap(),
-        &cmd.args,
-      )
-      .unwrap();
+      let program = CString::new(cmd.program.into_os_string().into_vec()).unwrap();
+      if let Some(env) = &cmd.env {
+        execve(&program, &cmd.args, env).unwrap();
+      } else {
+        execv(&program, &cmd.args).unwrap();
+      }
       unreachable!()
     }
   }

--- a/crates/tracexec-core/src/tracer.rs
+++ b/crates/tracexec-core/src/tracer.rs
@@ -30,6 +30,7 @@ use crate::{
     },
     options::SeccompBpf,
   },
+  elevate::EnvVars,
   event::{
     OutputMsg,
     TracerEventDetailsKind,
@@ -116,6 +117,8 @@ pub struct TracerBuilder {
   pub seccomp_bpf: SeccompBpf,
   pub ptrace_polling_delay: Option<u64>,
   pub ptrace_blocking: Option<bool>,
+  pub tracee_env: Option<EnvVars>,
+  pub tracexec_override_env: Option<EnvVars>,
 }
 
 impl TracerBuilder {
@@ -164,6 +167,22 @@ impl TracerBuilder {
   /// Default to current user.
   pub fn user(mut self, user: Option<User>) -> Self {
     self.user = user;
+    self
+  }
+
+  /// Sets the environment passed to the root tracee at exec time.
+  ///
+  /// When unset, the tracee inherits tracexec's current process environment.
+  pub fn tracee_env(mut self, env: Option<EnvVars>) -> Self {
+    self.tracee_env = env;
+    self
+  }
+
+  /// Sets the environment variables tracexec should consult for before using process env vars
+  ///
+  /// Or put it simply, this overrides std::env::vars for tracexec itself only.
+  pub fn tracexec_override_env(mut self, env: Option<EnvVars>) -> Self {
+    self.tracexec_override_env = env;
     self
   }
 

--- a/src/bpf.rs
+++ b/src/bpf.rs
@@ -68,6 +68,8 @@ pub async fn main(
   command: EbpfCommand,
   user: Option<User>,
   color: Color,
+  tracee_env: Option<tracexec_core::elevate::EnvVars>,
+  tracexec_override_env: Option<tracexec_core::elevate::EnvVars>,
 ) -> color_eyre::Result<()> {
   let obj = Box::leak(Box::new(MaybeUninit::uninit()));
   match command {
@@ -78,7 +80,7 @@ pub async fn main(
       log_args,
     } => {
       let modifier_args = modifier_args.processed();
-      let baseline = Arc::new(BaselineInfo::new()?);
+      let baseline = Arc::new(BaselineInfo::new_with_env(tracee_env.as_deref())?);
       let output = Cli::get_output(output, color)?;
       let printer = Printer::new(
         PrinterArgs::from_cli(&log_args, &modifier_args),
@@ -92,6 +94,8 @@ pub async fn main(
         .printer(printer)
         .baseline(baseline)
         .user(user)
+        .tracee_env(tracee_env.clone())
+        .tracexec_override_env(tracexec_override_env.clone())
         .modifier(modifier_args)
         .build_ebpf();
       let running_tracer = tracer.spawn(&cmd, obj, Some(output))?;
@@ -134,12 +138,16 @@ pub async fn main(
           pixel_height: 0,
         })?;
         (
-          BaselineInfo::with_pts(&pair.slave)?,
+          BaselineInfo::with_pts_and_env(&pair.slave, tracee_env.as_deref())?,
           TracerMode::Tui(Some(pair.slave)),
           Some(pair.master),
         )
       } else {
-        (BaselineInfo::new()?, TracerMode::Tui(None), None)
+        (
+          BaselineInfo::new_with_env(tracee_env.as_deref())?,
+          TracerMode::Tui(None),
+          None,
+        )
       };
       let baseline = Arc::new(baseline);
       let frame_rate = tui_args.frame_rate.unwrap_or(60.);
@@ -175,6 +183,8 @@ pub async fn main(
         .modifier(modifier_args)
         .filter(tracer_event_args.filter()?)
         .user(user)
+        .tracee_env(tracee_env.clone())
+        .tracexec_override_env(tracexec_override_env.clone())
         .tracer_tx(tracer_tx)
         .build_ebpf();
       let running_tracer = tracer.spawn(&cmd, obj, None)?;
@@ -208,7 +218,7 @@ pub async fn main(
       no_foreground,
     } => {
       let modifier_args = modifier_args.processed();
-      let baseline = Arc::new(BaselineInfo::new()?);
+      let baseline = Arc::new(BaselineInfo::new_with_env(tracee_env.as_deref())?);
       let output = Cli::get_output(output, color)?;
       let log_args = LogModeArgs {
         show_cmdline: false,
@@ -235,6 +245,8 @@ pub async fn main(
         .baseline(baseline.clone())
         .tracer_tx(tx)
         .user(user)
+        .tracee_env(tracee_env.clone())
+        .tracexec_override_env(tracexec_override_env.clone())
         .build_ebpf();
       let running_tracer = tracer.spawn(&cmd, obj, None)?;
       let should_exit = running_tracer.should_exit.clone();

--- a/src/log.rs
+++ b/src/log.rs
@@ -17,12 +17,17 @@
 // CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 use std::{
+  env,
+  ffi::OsString,
   path::PathBuf,
   sync::LazyLock,
 };
 
 use color_eyre::eyre::Result;
-use tracexec_core::cli::config::project_directory;
+use tracexec_core::{
+  cli::config::project_directory,
+  elevate,
+};
 use tracexec_tui::restore_tui;
 pub use tracing::*;
 use tracing_error::ErrorLayer;
@@ -39,9 +44,8 @@ static LOG_ENV: LazyLock<String> =
   LazyLock::new(|| concat!(env!("CARGO_CRATE_NAME"), "_LOGLEVEL").to_uppercase());
 
 pub fn get_data_dir() -> PathBuf {
-  if let Some(s) = std::env::var(concat!(env!("CARGO_CRATE_NAME"), "_DATA").to_uppercase())
-    .ok()
-    .map(PathBuf::from)
+  if let Some(s) =
+    env::var_os(concat!(env!("CARGO_CRATE_NAME"), "_DATA").to_uppercase()).map(PathBuf::from)
   {
     s
   } else if let Some(proj_dirs) = project_directory() {
@@ -51,7 +55,7 @@ pub fn get_data_dir() -> PathBuf {
   }
 }
 
-pub fn initialize_logging() -> Result<()> {
+pub fn initialize_logging(override_env: Option<&[(OsString, OsString)]>) -> Result<()> {
   let directory = get_data_dir();
   std::fs::create_dir_all(directory.clone())?;
   let log_path = directory.join(LOG_FILE);
@@ -65,12 +69,12 @@ pub fn initialize_logging() -> Result<()> {
     .with_target(false)
     .with_ansi(false);
 
-  let file_subscriber = if std::env::var(LOG_ENV.clone()).is_ok() {
-    file_subscriber.with_filter(tracing_subscriber::filter::EnvFilter::from_env(
-      LOG_ENV.clone(),
-    ))
-  } else if std::env::var("RUST_LOG").is_ok() {
-    file_subscriber.with_filter(tracing_subscriber::filter::EnvFilter::from_env("RUST_LOG"))
+  let file_subscriber = if let Some(value) = elevate::env_var_string(override_env, &LOG_ENV)
+    .or_else(|| elevate::env_var_string(override_env, "TRACEXEC_LOG_LEVEL"))
+  {
+    file_subscriber.with_filter(tracing_subscriber::filter::EnvFilter::new(value))
+  } else if let Some(value) = elevate::env_var_string(override_env, "RUST_LOG") {
+    file_subscriber.with_filter(tracing_subscriber::filter::EnvFilter::new(value))
   } else {
     file_subscriber.with_filter(tracing_subscriber::filter::EnvFilter::new(concat!(
       env!("CARGO_CRATE_NAME"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ use tracexec_core::{
       ExportFormat,
     },
   },
+  elevate,
   event::{
     TracerEvent,
     TracerEventDetails,
@@ -90,11 +91,22 @@ fn main() -> color_eyre::Result<()> {
     unreachable!();
   }
 
-  // Restore saved environment from a previous --elevate invocation.
-  // This must happen before logging, config loading, or any code that reads env vars.
-  if let Some(env_file) = &cli.restore_env_file {
-    tracexec_core::elevate::restore_env_from_file(env_file)?;
+  // Request the original environment from the unelevated parent. Only an
+  // allowlisted subset is consulted by elevated tracexec itself; the complete
+  // original environment is saved as data for the tracee's execve.
+  if cli.restore_env_socket.is_some() && !Uid::effective().is_root() {
+    bail!("--restore-env-socket is only available after privilege elevation");
   }
+  let restored_env = cli
+    .restore_env_socket
+    .take()
+    .map(|socket| elevate::request_env_from_parent(&socket))
+    .transpose()?;
+  let tracexec_env = restored_env
+    .as_ref()
+    .map(|env| elevate::filter_allowlisted_env(env));
+  let tracexec_env_ref = tracexec_env.as_deref();
+  let tracee_env = restored_env;
 
   // Apply project directory overrides from --elevate before anything
   // touches project_directory() (logging, config, themes).
@@ -107,7 +119,7 @@ fn main() -> color_eyre::Result<()> {
     tracexec_core::cli::config::set_project_dir_overrides(config_dir, data_dir, data_local_dir);
   }
 
-  if cli.color == Color::Auto && std::env::var_os("NO_COLOR").is_some() {
+  if cli.color == Color::Auto && elevate::env_var_os(tracexec_env_ref, "NO_COLOR").is_some() {
     // Respect NO_COLOR if --color=auto
     cli.color = Color::Never;
   }
@@ -120,17 +132,21 @@ fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
   }
   initialize_panic_handler();
-  log::initialize_logging()?;
+  log::initialize_logging(tracexec_env_ref)?;
   log::debug!("Commandline args: {:?}", cli);
 
   let runtime = tokio::runtime::Builder::new_multi_thread()
     .worker_threads(2)
     .enable_all()
     .build()?;
-  runtime.block_on(async_main(cli))
+  runtime.block_on(async_main(cli, tracee_env, tracexec_env))
 }
 
-async fn async_main(mut cli: Cli) -> color_eyre::Result<()> {
+async fn async_main(
+  mut cli: Cli,
+  tracee_env: Option<tracexec_core::elevate::EnvVars>,
+  tracexec_env: Option<tracexec_core::elevate::EnvVars>,
+) -> color_eyre::Result<()> {
   if let Some(cwd) = &cli.cwd {
     std::env::set_current_dir(cwd)?;
   }
@@ -173,7 +189,7 @@ async fn async_main(mut cli: Cli) -> color_eyre::Result<()> {
     } => {
       let modifier_args = modifier_args.processed();
       let output = Cli::get_output(output, cli.color)?;
-      let baseline = BaselineInfo::new()?;
+      let baseline = BaselineInfo::new_with_env(tracee_env.as_deref())?;
       let (tracer_tx, mut tracer_rx) = mpsc::unbounded_channel();
       let (tracer, token) = TracerBuilder::new()
         .mode(TracerMode::Log {
@@ -181,6 +197,7 @@ async fn async_main(mut cli: Cli) -> color_eyre::Result<()> {
         })
         .modifier(modifier_args)
         .user(user)
+        .tracee_env(tracee_env.clone())
         .tracer_tx(tracer_tx)
         .baseline(Arc::new(baseline))
         .filter(tracer_event_args.filter()?)
@@ -249,12 +266,16 @@ async fn async_main(mut cli: Cli) -> color_eyre::Result<()> {
           pixel_height: 0,
         })?;
         (
-          BaselineInfo::with_pts(&pair.slave)?,
+          BaselineInfo::with_pts_and_env(&pair.slave, tracee_env.as_deref())?,
           TracerMode::Tui(Some(pair.slave)),
           Some(pair.master),
         )
       } else {
-        (BaselineInfo::new()?, TracerMode::Tui(None), None)
+        (
+          BaselineInfo::new_with_env(tracee_env.as_deref())?,
+          TracerMode::Tui(None),
+          None,
+        )
       };
       let tracing_args = LogModeArgs {
         show_cmdline: false, // We handle cmdline in TUI
@@ -271,6 +292,7 @@ async fn async_main(mut cli: Cli) -> color_eyre::Result<()> {
         .mode(tracer_mode)
         .modifier(modifier_args.clone())
         .user(user)
+        .tracee_env(tracee_env.clone())
         .tracer_tx(tracer_tx)
         .baseline(baseline.clone())
         .filter(tracer_event_args.filter()?)
@@ -335,13 +357,14 @@ async fn async_main(mut cli: Cli) -> color_eyre::Result<()> {
         ..Default::default()
       };
       let (tracer_tx, tracer_rx) = mpsc::unbounded_channel();
-      let baseline = Arc::new(BaselineInfo::new()?);
+      let baseline = Arc::new(BaselineInfo::new_with_env(tracee_env.as_deref())?);
       let (tracer, token) = TracerBuilder::new()
         .mode(TracerMode::Log {
           foreground: tracing_args.foreground(),
         })
         .modifier(modifier_args)
         .user(user)
+        .tracee_env(tracee_env.clone())
         .tracer_tx(tracer_tx)
         .baseline(baseline.clone())
         .filter(TracerEventArgs::all().filter()?)
@@ -401,7 +424,7 @@ async fn async_main(mut cli: Cli) -> color_eyre::Result<()> {
     #[cfg(feature = "ebpf")]
     CliCommand::Ebpf { command } => {
       // TODO: warn if --user is set when not follow-forks
-      bpf::main(command, user, cli.color).await?;
+      bpf::main(command, user, cli.color, tracee_env, tracexec_env).await?;
     }
   }
   Ok(())

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -58,53 +58,80 @@ fn elevate_log_mode_runs_tracee_as_original_user() -> Result<(), Box<dyn std::er
 #[test]
 #[file_serial(ignored)]
 #[ignore = "root"]
-fn elevate_env_file_preserves_custom_env_var() -> Result<(), Box<dyn std::error::Error>> {
-  // Test that --restore-env-file restores environment variables correctly.
-  // We create an env file with a known custom var AND SUDO_USER removed,
-  // then verify the tracee sees the custom var but not SUDO_USER.
-  use std::io::Write;
+fn restore_env_socket_passes_full_env_to_tracee() -> Result<(), Box<dyn std::error::Error>> {
+  use std::{
+    io::{
+      Read,
+      Write,
+    },
+    os::{
+      linux::net::SocketAddrExt,
+      unix::net::UnixListener,
+    },
+    thread,
+    time::{
+      Duration,
+      SystemTime,
+      UNIX_EPOCH,
+    },
+  };
 
   let username = std::env::var("SUDO_USER").unwrap_or_else(|_| "nobody".to_string());
-  let uid: u32 = std::env::var("SUDO_UID")
-    .ok()
-    .and_then(|s| s.parse().ok())
-    .unwrap_or(65534);
+  let socket_name = format!(
+    "tracexec-test-env-{}-{}",
+    std::process::id(),
+    SystemTime::now().duration_since(UNIX_EPOCH)?.as_nanos()
+  );
+  let listener = UnixListener::bind_addr(&std::os::unix::net::SocketAddr::from_abstract_name(
+    socket_name.as_bytes(),
+  )?)?;
 
-  // Build env file content: include a test marker var and exclude SUDO_* vars
   let mut env_data = Vec::new();
   env_data.extend_from_slice(b"TRACEXEC_TEST_MARKER=preserved_value\0");
+  env_data.extend_from_slice(b"SUDO_USER=from_socket\0");
   env_data.extend_from_slice(b"HOME=/tmp\0");
   env_data
     .extend_from_slice(format!("PATH={}\0", std::env::var("PATH").unwrap_or_default()).as_bytes());
 
-  // Write env file with correct permissions (0600) and ownership
-  let dir = std::env::temp_dir();
-  let mut tmpfile = tempfile::Builder::new()
-    .prefix("tracexec-env-test-")
-    .tempfile_in(&dir)?;
-  tmpfile.write_all(&env_data)?;
-  tmpfile.flush()?;
-  let env_path = tmpfile.into_temp_path();
-
-  // chown the file to the target user
-  nix::unistd::chown(
-    env_path.as_ref() as &std::path::Path,
-    Some(nix::unistd::Uid::from_raw(uid)),
-    None,
-  )?;
+  let server = thread::spawn(move || -> std::io::Result<()> {
+    listener.set_nonblocking(true)?;
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let (mut stream, _) = loop {
+      match listener.accept() {
+        Ok(accepted) => break accepted,
+        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+          if std::time::Instant::now() >= deadline {
+            return Err(std::io::Error::new(
+              std::io::ErrorKind::TimedOut,
+              "timed out waiting for env request",
+            ));
+          }
+          thread::sleep(Duration::from_millis(10));
+        }
+        Err(e) => return Err(e),
+      }
+    };
+    let mut request = [0; 15];
+    stream.read_exact(&mut request)?;
+    assert_eq!(&request, b"tracexec-env-v1");
+    stream.write_all(&(env_data.len() as u32).to_be_bytes())?;
+    stream.write_all(&env_data)?;
+    stream.flush()
+  });
 
   let mut cmd = Command::new(cargo::cargo_bin!());
   cmd
     .arg("--user")
     .arg(&username)
-    .arg("--restore-env-file")
-    .arg(env_path.as_os_str())
+    .arg("--restore-env-socket")
+    .arg(&socket_name)
     .arg("log")
     .arg("--")
     .arg("sh")
     .arg("-c")
     .arg("echo MARKER=$TRACEXEC_TEST_MARKER SUDO=$SUDO_USER");
   let output = cmd.output()?;
+  server.join().expect("env server panicked")?;
   let stdout = String::from_utf8_lossy(&output.stdout);
 
   assert!(
@@ -112,8 +139,8 @@ fn elevate_env_file_preserves_custom_env_var() -> Result<(), Box<dyn std::error:
     "Custom env var should be preserved, got stdout: {stdout}"
   );
   assert!(
-    stdout.contains("SUDO=\n"),
-    "SUDO_USER should be empty/absent, got stdout: {stdout}"
+    stdout.contains("SUDO=from_socket\n"),
+    "SUDO_USER should come from the transferred original env, got stdout: {stdout}"
   );
   Ok(())
 }


### PR DESCRIPTION
Fix the TOCTOU caused by passing environment variables via a file reported in https://github.com/kxxt/tracexec/pull/222
by passing them via a temporary abstract Unix Domain Socket.

Additionally, harden the environment variable restore code:
- We no longer restores all environment variables in the privileged process.
  Instead, we only restore environment variables that the privileged process itself uses.
- We still restore the full environment variables for the tracee by passing them to execve.
