### PR TITLE
ukci: use PAT token for automation

### DIFF
--- a/.github/workflows/update-ukci.yml
+++ b/.github/workflows/update-ukci.yml
@@ -63,7 +63,7 @@ jobs:
         if: steps.pending-pr.outputs.skip != 'true'
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GH_AUTOMATION_TOKEN }}
           branch: automation/update-ukci-kernels
           delete-branch: true
           commit-message: "chore: update UKCI kernels"


### PR DESCRIPTION
Unfortunately PRs created by GH actions cannot trigger other workflows, as seen in https://github.com/kxxt/tracexec/pull/256