### PR TITLE
bpf: stabilize eBPF backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ Please [read the gdb-launcher example](demonstration/gdb-launcher/README.md) for
 
 ### eBPF mode
 
-The eBPF mode is currently experimental.
-The minimum supported kernel version is 5.17.
+Please check [platform support status](https://tracexec.kxxt.dev/support.html#linux-kernel-support-status) before using the eBPF backend.
 
 The following examples shows how to use eBPF in TUI mode.
 The `eBPF` command also supports regular `log` and `collect` subcommands.
@@ -155,6 +154,7 @@ Options:
   -P, --profile <PROFILE>  Load profile from this path
       --no-profile         Do not load profiles
   -u, --user <USER>        Run as user. This option is only available when running tracexec as root
+      --elevate            Re-execute tracexec with privilege elevation (e.g. via sudo). The original user credentials are saved and the tracee will run as the original user.
   -h, --help               Print help
   -V, --version            Print version
 
@@ -191,6 +191,10 @@ Options:
           Do not show timestamp information
       --inline-timestamp-format <INLINE_TIMESTAMP_FORMAT>
           Set the format of inline timestamp. See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for available options.
+      --collect-cgroup
+          Collect cgroup information
+      --no-collect-cgroup
+          Do not collect cgroup information
       --seccomp-bpf <SECCOMP_BPF>
           Controls whether to enable seccomp-bpf optimization, which greatly improves performance [default: auto] [possible values: auto, on, off]
       --polling-interval <POLLING_INTERVAL>
@@ -315,6 +319,10 @@ Options:
           Do not show timestamp information
       --inline-timestamp-format <INLINE_TIMESTAMP_FORMAT>
           Set the format of inline timestamp. See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for available options.
+      --collect-cgroup
+          Collect cgroup information
+      --no-collect-cgroup
+          Do not collect cgroup information
       --seccomp-bpf <SECCOMP_BPF>
           Controls whether to enable seccomp-bpf optimization, which greatly improves performance [default: auto] [possible values: auto, on, off]
       --polling-interval <POLLING_INTERVAL>
@@ -365,6 +373,10 @@ Options:
           Do not show timestamp information
       --inline-timestamp-format <INLINE_TIMESTAMP_FORMAT>
           Set the format of inline timestamp. See https://docs.rs/chrono/latest/chrono/format/strftime/index.html for available options.
+      --collect-cgroup
+          Collect cgroup information
+      --no-collect-cgroup
+          Do not collect cgroup information
       --seccomp-bpf <SECCOMP_BPF>
           Controls whether to enable seccomp-bpf optimization, which greatly improves performance [default: auto] [possible values: auto, on, off]
       --polling-interval <POLLING_INTERVAL>

--- a/README.template.md
+++ b/README.template.md
@@ -69,8 +69,7 @@ Please [read the gdb-launcher example](demonstration/gdb-launcher/README.md) for
 
 ### eBPF mode
 
-The eBPF mode is currently experimental.
-The minimum supported kernel version is 5.17.
+Please check [platform support status](https://tracexec.kxxt.dev/support.html#linux-kernel-support-status) before using the eBPF backend.
 
 The following examples shows how to use eBPF in TUI mode.
 The `eBPF` command also supports regular `log` and `collect` subcommands.

--- a/src/bpf.rs
+++ b/src/bpf.rs
@@ -169,7 +169,6 @@ pub async fn main(
         pty_master,
         current_theme(),
       )?;
-      app.activate_experiment("eBPF");
       let printer = Printer::new(
         PrinterArgs::from_cli(&log_args, &modifier_args),
         baseline.clone(),


### PR DESCRIPTION
We are finally here :tada:!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--collect-cgroup` and `--no-collect-cgroup` options to control whether cgroup information is collected.
  * Added a top-level `--elevate` option to rerun with privilege elevation while preserving the traced program’s original user credentials.

* **Documentation**
  * Updated eBPF mode guidance to direct users to the platform support status page before using the eBPF backend.
  * Refreshed CLI help text across global, TUI, log, and collect/export modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->