### PR TITLE
bpf: switch to sleepable helpers/kfuncs in sleepable context

### DIFF
--- a/crates/tracexec-backend-ebpf/src/common.h
+++ b/crates/tracexec-backend-ebpf/src/common.h
@@ -61,6 +61,7 @@ extern void bpf_rcu_read_unlock(void) __ksym;
 
 #define MIN_KERNEL_VERSION_FOR_RCU_KFUNC KERNEL_VERSION(6, 2, 0)
 #define MIN_KERNEL_VERSION_FOR_ITER_BITS KERNEL_VERSION(6, 11, 0)
+#define MIN_KERNEL_VERSION_FOR_COPY_FROM_USER_STR KERNEL_VERSION(6, 12, 0)
 
 int __always_inline rcu_read_lock() {
   if (LINUX_KERNEL_VERSION >= MIN_KERNEL_VERSION_FOR_RCU_KFUNC) {

--- a/crates/tracexec-backend-ebpf/src/test_utils.rs
+++ b/crates/tracexec-backend-ebpf/src/test_utils.rs
@@ -136,6 +136,7 @@ pub fn prepare_execve_fentry_fexit(
   open_skel.progs.sys_execve_fentry.set_flags(BPF_F_SLEEPABLE);
   if let Some(rodata) = open_skel.maps.rodata_data.as_deref_mut() {
     rodata.tracexec_config.follow_fork = MaybeUninit::new(false);
+    rodata.tracexec_config.sleepable = MaybeUninit::new(true);
   }
   None
 }
@@ -181,6 +182,7 @@ pub fn prepare_execveat_fentry_fexit(
     .set_flags(BPF_F_SLEEPABLE);
   if let Some(rodata) = open_skel.maps.rodata_data.as_deref_mut() {
     rodata.tracexec_config.follow_fork = MaybeUninit::new(false);
+    rodata.tracexec_config.sleepable = MaybeUninit::new(true);
   }
   None
 }
@@ -198,6 +200,7 @@ pub fn prepare_compat_execve(
   open_skel.progs.compat_sys_execve.set_flags(BPF_F_SLEEPABLE);
   if let Some(rodata) = open_skel.maps.rodata_data.as_deref_mut() {
     rodata.tracexec_config.follow_fork = MaybeUninit::new(false);
+    rodata.tracexec_config.sleepable = MaybeUninit::new(true);
   }
   None
 }
@@ -220,6 +223,7 @@ pub fn prepare_compat_execveat(
     .set_flags(BPF_F_SLEEPABLE);
   if let Some(rodata) = open_skel.maps.rodata_data.as_deref_mut() {
     rodata.tracexec_config.follow_fork = MaybeUninit::new(false);
+    rodata.tracexec_config.sleepable = MaybeUninit::new(true);
   }
   None
 }

--- a/crates/tracexec-backend-ebpf/src/tracer.rs
+++ b/crates/tracexec-backend-ebpf/src/tracer.rs
@@ -797,6 +797,7 @@ impl EbpfTracer {
         .set_autoload(false);
       // Check if we can use sleepable fentry
       if can_i_use_sleepable_fentry(kconfig.as_ref(), override_env) {
+        rodata.tracexec_config.sleepable = MaybeUninit::new(true);
         // Can use sleepable fentry :(
         open_skel.progs.sys_execve_fentry.set_flags(BPF_F_SLEEPABLE);
         open_skel

--- a/crates/tracexec-backend-ebpf/src/tracexec_system.bpf.c
+++ b/crates/tracexec-backend-ebpf/src/tracexec_system.bpf.c
@@ -24,12 +24,14 @@ static pid_t tracee_tgid = 0;
 const volatile struct {
   u32 nofile;
   bool follow_fork;
+  bool sleepable;
   pid_t tracee_pid;
   unsigned int tracee_pidns_inum;
 } tracexec_config = {
     // https://www.kxxt.dev/blog/max-possible-value-of-rlimit-nofile/
     .nofile = 2147483584,
     .follow_fork = false,
+    .sleepable = false,
     .tracee_pid = 0,
     .tracee_pidns_inum = 0,
 };
@@ -119,6 +121,8 @@ struct fdset_word_reader_context {
 };
 
 static int read_strings(u32 index, struct reader_context *ctx);
+static __always_inline int read_user_string(void *dst, u32 size,
+                                            const void *unsafe_ptr);
 static int read_fds(struct exec_event *event);
 static int _read_fd(unsigned int fd_num, struct file **fd_array,
                     struct exec_event *event, bool cloexec,
@@ -280,8 +284,8 @@ trace_exec_common(bool is_execveat, bool is_compat, const u8 *base_filename,
     debug("filename is NULL");
     event->base_filename[0] = '\0';
   } else {
-    ret = bpf_probe_read_user_str(
-        event->base_filename, sizeof(event->base_filename), base_filename);
+    ret = read_user_string(event->base_filename, sizeof(event->base_filename),
+                           base_filename);
     if (ret < 0) {
       event->header.flags |= FILENAME_READ_ERR;
     } else if (ret == sizeof(event->base_filename)) {
@@ -1025,15 +1029,32 @@ ptr_err:
   return 1;
 }
 
+static __always_inline int read_user_pointer(void *dst, u32 size,
+                                             const void *unsafe_ptr) {
+  if (tracexec_config.sleepable) {
+    return bpf_copy_from_user(dst, size, unsafe_ptr);
+  }
+  return bpf_probe_read_user(dst, size, unsafe_ptr);
+}
+
+static __always_inline int read_user_string(void *dst, u32 size,
+                                            const void *unsafe_ptr) {
+  if (tracexec_config.sleepable &&
+      LINUX_KERNEL_VERSION >= MIN_KERNEL_VERSION_FOR_COPY_FROM_USER_STR) {
+    return bpf_copy_from_user_str(dst, size, unsafe_ptr, BPF_ANY);
+  }
+  return bpf_probe_read_user_str(dst, size, unsafe_ptr);
+}
+
 static int read_strings(u32 index, struct reader_context *ctx) {
   struct exec_event *event = ctx->event;
   const u8 *argp = NULL;
   int ret;
   if (!ctx->is_compat)
-    ret = bpf_probe_read_user(&argp, sizeof(argp), &ctx->ptr[index]);
+    ret = read_user_pointer(&argp, sizeof(argp), &ctx->ptr[index]);
   else
-    ret = bpf_probe_read_user(&argp, sizeof(u32),
-                              (void *)ctx->ptr + index * sizeof(u32));
+    ret = read_user_pointer(&argp, sizeof(u32),
+                            (void *)ctx->ptr + index * sizeof(u32));
   if (ret < 0) {
     event->header.flags |= PTR_READ_FAILURE;
     debug("Failed to read pointer to arg: %d", ret);
@@ -1070,8 +1091,7 @@ static int read_strings(u32 index, struct reader_context *ctx) {
   entry->header.eid = event->header.eid;
   entry->header.id = index + ctx->index * event->count[0];
   entry->header.flags = 0;
-  s64 bytes_read =
-      bpf_probe_read_user_str(entry->data, sizeof(entry->data), argp);
+  s64 bytes_read = read_user_string(entry->data, sizeof(entry->data), argp);
   if (bytes_read < 0) {
     debug("failed to read arg %d(addr:%x) from userspace", index, argp);
     entry->header.flags |= STR_READ_FAILURE;

--- a/crates/tracexec-backend-ebpf/src/tracexec_system.bpf.c
+++ b/crates/tracexec-backend-ebpf/src/tracexec_system.bpf.c
@@ -1101,12 +1101,15 @@ static int read_strings(u32 index, struct reader_context *ctx) {
   } else if (bytes_read == 0) {
     entry->data[0] = '\0';
     bytes_read = 1;
-  } else if (bytes_read == sizeof(entry->data)) {
-    entry->header.flags |= POSSIBLE_TRUNCATION;
   }
-  ret = bpf_ringbuf_output(&events, entry,
-                           sizeof(struct tracexec_event_header) + bytes_read,
-                           BPF_RB_FORCE_WAKEUP);
+  u32 event_size = sizeof(struct tracexec_event_header) + bytes_read;
+  barrier_var(event_size);
+  // Don't let clang optimize away the following check,
+  // which is required by the verifier.
+  if (event_size > sizeof(*entry)) {
+    event_size = sizeof(*entry);
+  }
+  ret = bpf_ringbuf_output(&events, entry, event_size, BPF_RB_FORCE_WAKEUP);
   bpf_map_delete_elem(&cache, &key);
   if (ret < 0) {
     event->header.flags |= OUTPUT_FAILURE;


### PR DESCRIPTION
We enabled sleepable eBPF some time ago but didn't switch the helpers/kfuncs to the sleepable variant. This PR does it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for sleepable user-memory reads when collecting command-line and environment data, improving compatibility on newer kernels.

* **Bug Fixes**
  * Improved handling of argument and environment string lengths by using conditional user-memory read helpers and more accurate event payload sizing.
  * Ensured sleepable execution is consistently enabled across relevant tracing paths for more reliable event capture.

* **Chores**
  * Introduced a kernel-version compile-time threshold used for safer string reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->