### PR TITLE
ebpf: add verifier complexity test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 # BPF
 *.skel.rs
 *.bpf.o
+/verifier-complexity
+/verifier-complexity-plots
 # Clangd
 .cache
 compile_commands.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3161,6 +3161,8 @@ dependencies = [
  "regex-lite",
  "rstest",
  "rusty-fork",
+ "serde",
+ "serde_json",
  "serial_test",
  "tempfile",
  "tokio",

--- a/book/dev/tests.md
+++ b/book/dev/tests.md
@@ -24,6 +24,21 @@ For example, if you are testing on a x86_64 linux machine, use
 CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' cargo test --workspace -- --ignored
 ```
 
+## eBPF Verifier Complexity
+
+Verifier complexity collection is available as an optional UKCI-style Nix runner.
+It boots the same UKCI kernels in QEMU, loads tracexec's eBPF programs with
+verifier stats enabled, and writes one JSON file per kernel/LLVM combination:
+
+```bash
+nix run .#ukci-complexity
+```
+
+By default, results are written to `verifier-complexity/`.
+Set `UKCI_COMPLEXITY_OUT_DIR` to use a different output directory.
+This runner is intentionally separate from `ukci` and is not part of the
+required UKCI test pass.
+
 ## Test Coverage
 
 Most of the time you do not need to calculate the test coverage by yourself because we are tracking

--- a/book/dev/tests.md
+++ b/book/dev/tests.md
@@ -39,6 +39,17 @@ Set `UKCI_COMPLEXITY_OUT_DIR` to use a different output directory.
 This runner is intentionally separate from `ukci` and is not part of the
 required UKCI test pass.
 
+To plot the collected results from the repository root:
+
+```bash
+nix run .#plot-verifier-complexity -- verifier-complexity
+```
+
+The plotting script writes charts and a summary under
+`verifier-complexity-plots/` by default. Use `-o` to choose another output
+directory, and `--log-scale` when comparing runs with large differences between
+the smallest and largest verifier counts.
+
 ## Test Coverage
 
 Most of the time you do not need to calculate the test coverage by yourself because we are tracking

--- a/crates/tracexec-backend-ebpf/Cargo.toml
+++ b/crates/tracexec-backend-ebpf/Cargo.toml
@@ -18,6 +18,7 @@ default = ["vendored-libbpf"]
 bpfcov = ["dep:bpfcov", "dep:regex-lite"]
 ebpf-debug = []
 static = ["libbpf-sys/static"]
+verifier-complexity = ["dep:serde", "dep:serde_json"]
 vendored = ["libbpf-sys/vendored", "vendored-libbpf"]
 vendored-libbpf = ["libbpf-sys/vendored-libbpf", "libbpf-cargo/default"]
 
@@ -38,6 +39,8 @@ libbpf-rs = { version = "0.26.1", default-features = false }
 libbpf-sys = { version = "1", default-features = false }
 procfs = "0.18.0"
 bpfcov = { version = "0.3.0-alpha.1", optional = true }
+serde = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 
 
 [build-dependencies]
@@ -58,3 +61,8 @@ path = "../../fixtures/compat-exec.rs"
 [[bin]]
 name = "special-fds-exec"
 path = "../../fixtures/special-fds-exec.rs"
+
+[[bin]]
+name = "tracexec-verifier-complexity"
+path = "src/bin/verifier_complexity.rs"
+required-features = ["verifier-complexity"]

--- a/crates/tracexec-backend-ebpf/src/bin/verifier_complexity.rs
+++ b/crates/tracexec-backend-ebpf/src/bin/verifier_complexity.rs
@@ -1,0 +1,542 @@
+use std::{
+  env,
+  io,
+  mem::MaybeUninit,
+  os::unix::fs::MetadataExt,
+};
+
+use color_eyre::{
+  Result,
+  eyre::{
+    Context,
+    bail,
+    eyre,
+  },
+};
+use libbpf_rs::{
+  AsRawLibbpf,
+  num_possible_cpus,
+  skel::{
+    OpenSkel,
+    SkelBuilder,
+  },
+};
+use libbpf_sys::{
+  BPF_F_NO_PREALLOC,
+  BPF_F_SLEEPABLE,
+};
+use serde::Serialize;
+use tracexec_backend_ebpf::{
+  bpf::skel::{
+    OpenTracexecSystemSkel,
+    TracexecSystemSkelBuilder,
+  },
+  probe::{
+    can_i_use_sleepable_fentry,
+    kernel_have_ftrace_with_direct_calls,
+    kernel_have_syscall_wrappers,
+    kernel_rejects_syscall_wrapper_kprobes,
+    kernel_supports_sleepable_no_prealloc_hash_maps,
+  },
+  test_utils::{
+    KCONFIG,
+    disable_all_programs,
+    prepare_execve_fentry_fexit,
+    prepare_execve_kprobe_kretprobe,
+    prepare_execveat_fentry_fexit,
+    prepare_execveat_kprobe_kretprobe,
+    prepare_handle_exit_only,
+    prepare_trace_fork_only,
+  },
+};
+
+const BPF_LOG_STATS: u32 = 4;
+const DEFAULT_LOG_BYTES: usize = 1024 * 1024;
+const COLLECTION: &str = "tracexec_system";
+
+type PrepareFn = for<'obj> fn(&mut OpenTracexecSystemSkel<'obj>) -> Result<()>;
+type SkipFn = fn() -> Option<&'static str>;
+
+struct LoadCase {
+  name: &'static str,
+  prepare: PrepareFn,
+  skip: SkipFn,
+  skip_invalid_argument: bool,
+}
+
+struct VerifierLog {
+  program: String,
+  buf: Vec<u8>,
+}
+
+#[derive(Debug)]
+struct VerifierMetrics {
+  insns_processed: u64,
+  insns_limit: u64,
+  max_states_per_insn: u64,
+  total_states: u64,
+  peak_states: u64,
+  mark_read: u64,
+  verification_time_microseconds: Option<u64>,
+  stack_depths: Vec<u64>,
+}
+
+#[derive(Serialize)]
+struct ComplexityRecord {
+  collection: &'static str,
+  build: String,
+  load: &'static str,
+  program: String,
+  arch: &'static str,
+  kernel_release: String,
+  insns_processed: u64,
+  insns_limit: u64,
+  max_states_per_insn: u64,
+  total_states: u64,
+  peak_states: u64,
+  mark_read: u64,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  verification_time_microseconds: Option<u64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  stack_depth: Option<u64>,
+  stack_depths: Vec<u64>,
+}
+
+fn main() -> Result<()> {
+  color_eyre::install()?;
+  bump_memlock_rlimit()?;
+
+  let build = env::var("TRACEXEC_VERIFIER_BUILD").unwrap_or_else(|_| "default".to_string());
+  let kernel_release = std::fs::read_to_string("/proc/sys/kernel/osrelease")
+    .unwrap_or_else(|_| "unknown".to_string())
+    .trim()
+    .to_string();
+  let log_bytes = env::var("TRACEXEC_VERIFIER_LOG_BYTES")
+    .ok()
+    .map(|v| v.parse::<usize>())
+    .transpose()
+    .wrap_err("invalid TRACEXEC_VERIFIER_LOG_BYTES")?
+    .unwrap_or(DEFAULT_LOG_BYTES);
+
+  let mut records = Vec::new();
+  for case in load_cases() {
+    records.extend(run_case(&case, &build, &kernel_release, log_bytes)?);
+  }
+  if records.is_empty() {
+    bail!("no verifier complexity records were collected");
+  }
+
+  records.sort_by(|a, b| (a.load, a.program.as_str()).cmp(&(b.load, b.program.as_str())));
+  serde_json::to_writer_pretty(io::stdout(), &records)?;
+  println!();
+  Ok(())
+}
+
+fn bump_memlock_rlimit() -> Result<()> {
+  let rlimit = nix::libc::rlimit {
+    rlim_cur: 128 << 20,
+    rlim_max: 128 << 20,
+  };
+
+  if unsafe { nix::libc::setrlimit(nix::libc::RLIMIT_MEMLOCK, &rlimit) } != 0 {
+    bail!("failed to increase RLIMIT_MEMLOCK");
+  }
+  Ok(())
+}
+
+fn load_cases() -> Vec<LoadCase> {
+  let mut cases = vec![
+    LoadCase {
+      name: "production",
+      prepare: prepare_production,
+      skip: never_skip,
+      skip_invalid_argument: false,
+    },
+    LoadCase {
+      name: "trace-fork",
+      prepare: prepare_trace_fork,
+      skip: never_skip,
+      skip_invalid_argument: false,
+    },
+    LoadCase {
+      name: "process-free",
+      prepare: prepare_process_free,
+      skip: never_skip,
+      skip_invalid_argument: false,
+    },
+    LoadCase {
+      name: "handle-exit",
+      prepare: prepare_handle_exit,
+      skip: never_skip,
+      skip_invalid_argument: false,
+    },
+    LoadCase {
+      name: "execve-kprobe",
+      prepare: prepare_execve_kprobe,
+      skip: skip_syscall_wrapper_kprobe,
+      skip_invalid_argument: false,
+    },
+    LoadCase {
+      name: "execveat-kprobe",
+      prepare: prepare_execveat_kprobe,
+      skip: skip_syscall_wrapper_kprobe,
+      skip_invalid_argument: false,
+    },
+    LoadCase {
+      name: "execve-fentry",
+      prepare: prepare_execve_fentry,
+      skip: skip_fentry,
+      skip_invalid_argument: true,
+    },
+    LoadCase {
+      name: "execveat-fentry",
+      prepare: prepare_execveat_fentry,
+      skip: skip_fentry,
+      skip_invalid_argument: true,
+    },
+  ];
+
+  #[cfg(target_arch = "x86_64")]
+  {
+    cases.extend([
+      LoadCase {
+        name: "compat-execve-fentry",
+        prepare: prepare_compat_execve_fentry,
+        skip: skip_fentry,
+        skip_invalid_argument: true,
+      },
+      LoadCase {
+        name: "compat-execveat-fentry",
+        prepare: prepare_compat_execveat_fentry,
+        skip: skip_fentry,
+        skip_invalid_argument: true,
+      },
+    ]);
+  }
+
+  cases
+}
+
+fn never_skip() -> Option<&'static str> {
+  None
+}
+
+fn skip_fentry() -> Option<&'static str> {
+  (!kernel_have_ftrace_with_direct_calls(KCONFIG.as_ref(), None))
+    .then_some("missing CONFIG_DYNAMIC_FTRACE_WITH_DIRECT_CALLS")
+}
+
+fn skip_syscall_wrapper_kprobe() -> Option<&'static str> {
+  kernel_rejects_syscall_wrapper_kprobes(KCONFIG.as_ref())
+    .then_some("kernel rejects syscall-wrapper kprobes")
+}
+
+fn run_case(
+  case: &LoadCase,
+  build: &str,
+  kernel_release: &str,
+  log_bytes: usize,
+) -> Result<Vec<ComplexityRecord>> {
+  if let Some(reason) = (case.skip)() {
+    eprintln!("skipping {}: {reason}", case.name);
+    return Ok(Vec::new());
+  }
+
+  let mut obj = MaybeUninit::uninit();
+  let builder = TracexecSystemSkelBuilder::default();
+  let mut open_skel = builder.open(&mut obj)?;
+  (case.prepare)(&mut open_skel)
+    .with_context(|| format!("failed to prepare load case {}", case.name))?;
+  apply_common_map_setup(&mut open_skel)?;
+
+  let logs = install_verifier_logs(&mut open_skel, log_bytes)
+    .with_context(|| format!("failed to install verifier logs for {}", case.name))?;
+
+  let _skel = match open_skel.load() {
+    Ok(skel) => skel,
+    Err(err)
+      if case.skip_invalid_argument
+        && format!("{err:?}").contains("Invalid argument (os error 22)") =>
+    {
+      eprintln!(
+        "skipping {}: kernel rejected this program flavor: {err}",
+        case.name
+      );
+      return Ok(Vec::new());
+    }
+    Err(err) => return Err(err).with_context(|| format!("failed to load {}", case.name)),
+  };
+
+  logs
+    .into_iter()
+    .map(|log| {
+      let text = verifier_log_text(&log.buf);
+      let metrics = parse_verifier_metrics(&text).ok_or_else(|| {
+        eyre!(
+          "verifier metrics not found for {} in load case {}; log was:\n{}",
+          log.program,
+          case.name,
+          text
+        )
+      })?;
+      let stack_depth = metrics.stack_depths.iter().copied().max();
+      Ok(ComplexityRecord {
+        collection: COLLECTION,
+        build: build.to_string(),
+        load: case.name,
+        program: log.program,
+        arch: env::consts::ARCH,
+        kernel_release: kernel_release.to_string(),
+        insns_processed: metrics.insns_processed,
+        insns_limit: metrics.insns_limit,
+        max_states_per_insn: metrics.max_states_per_insn,
+        total_states: metrics.total_states,
+        peak_states: metrics.peak_states,
+        mark_read: metrics.mark_read,
+        verification_time_microseconds: metrics.verification_time_microseconds,
+        stack_depth,
+        stack_depths: metrics.stack_depths,
+      })
+    })
+    .collect()
+}
+
+fn install_verifier_logs(
+  open_skel: &mut OpenTracexecSystemSkel<'_>,
+  log_bytes: usize,
+) -> Result<Vec<VerifierLog>> {
+  if log_bytes == 0 {
+    bail!("verifier log buffer size must be greater than zero");
+  }
+
+  let mut logs = Vec::new();
+  for mut prog in open_skel.open_object_mut().progs_mut() {
+    if !prog.autoload() {
+      continue;
+    }
+    let program = prog.name().to_string_lossy().into_owned();
+    prog.set_log_level(BPF_LOG_STATS);
+    let mut buf = vec![0_u8; log_bytes];
+    let ret = unsafe {
+      libbpf_sys::bpf_program__set_log_buf(
+        prog.as_libbpf_object().as_ptr(),
+        buf.as_mut_ptr().cast(),
+        buf
+          .len()
+          .try_into()
+          .map_err(|_| eyre!("verifier log buffer is too large"))?,
+      )
+    };
+    if ret != 0 {
+      bail!(
+        "bpf_program__set_log_buf failed for {program}: {}",
+        io::Error::from_raw_os_error(-ret)
+      );
+    }
+    logs.push(VerifierLog { program, buf });
+  }
+
+  if logs.is_empty() {
+    bail!("load case did not enable any BPF programs");
+  }
+  Ok(logs)
+}
+
+fn verifier_log_text(buf: &[u8]) -> String {
+  let len = buf.iter().position(|b| *b == 0).unwrap_or(buf.len());
+  String::from_utf8_lossy(&buf[..len]).into_owned()
+}
+
+fn parse_verifier_metrics(log: &str) -> Option<VerifierMetrics> {
+  let mut verification_time_microseconds = None;
+  let mut stack_depths = Vec::new();
+  let mut processed = None;
+
+  for line in log.lines().map(str::trim) {
+    if let Some(value) = line
+      .strip_prefix("verification time ")
+      .and_then(|s| s.strip_suffix(" usec"))
+    {
+      verification_time_microseconds = value.parse().ok();
+    } else if let Some(value) = line.strip_prefix("stack depth ") {
+      stack_depths = value
+        .split('+')
+        .filter(|part| !part.is_empty())
+        .map(str::parse)
+        .collect::<Result<Vec<_>, _>>()
+        .ok()?;
+    } else if line.starts_with("processed ") {
+      processed = Some(parse_processed_line(line)?);
+    }
+  }
+
+  let (insns_processed, insns_limit, max_states_per_insn, total_states, peak_states, mark_read) =
+    processed?;
+
+  Some(VerifierMetrics {
+    insns_processed,
+    insns_limit,
+    max_states_per_insn,
+    total_states,
+    peak_states,
+    mark_read,
+    verification_time_microseconds,
+    stack_depths,
+  })
+}
+
+fn parse_processed_line(line: &str) -> Option<(u64, u64, u64, u64, u64, u64)> {
+  let parts: Vec<_> = line.split_whitespace().collect();
+  if parts.len() < 13
+    || parts[0] != "processed"
+    || parts[2] != "insns"
+    || parts[3] != "(limit"
+    || parts[5] != "max_states_per_insn"
+    || parts[7] != "total_states"
+    || parts[9] != "peak_states"
+    || parts[11] != "mark_read"
+  {
+    return None;
+  }
+
+  Some((
+    parts[1].parse().ok()?,
+    parts[4].trim_end_matches(')').parse().ok()?,
+    parts[6].parse().ok()?,
+    parts[8].parse().ok()?,
+    parts[10].parse().ok()?,
+    parts[12].parse().ok()?,
+  ))
+}
+
+fn apply_common_map_setup(open_skel: &mut OpenTracexecSystemSkel<'_>) -> Result<()> {
+  if kernel_supports_sleepable_no_prealloc_hash_maps() {
+    open_skel
+      .maps
+      .tracee_closure
+      .set_map_flags(BPF_F_NO_PREALLOC)?;
+  }
+  Ok(())
+}
+
+fn prepare_production(open_skel: &mut OpenTracexecSystemSkel<'_>) -> Result<()> {
+  let rodata = open_skel
+    .maps
+    .rodata_data
+    .as_deref_mut()
+    .ok_or_else(|| eyre!("missing rodata map"))?;
+  rodata.tracexec_config.follow_fork = MaybeUninit::new(false);
+  rodata.tracexec_config.tracee_pid = 0;
+  rodata.tracexec_config.tracee_pidns_inum = std::fs::metadata("/proc/self/ns/pid")?.ino() as u32;
+
+  if !kernel_have_ftrace_with_direct_calls(KCONFIG.as_ref(), None) {
+    open_skel.progs.sys_execve_fentry.set_autoload(false);
+    open_skel.progs.sys_execveat_fentry.set_autoload(false);
+    open_skel.progs.sys_exit_execve_fexit.set_autoload(false);
+    open_skel.progs.sys_exit_execveat_fexit.set_autoload(false);
+  } else {
+    open_skel.progs.sys_execve_kprobe.set_autoload(false);
+    open_skel.progs.sys_execveat_kprobe.set_autoload(false);
+    open_skel
+      .progs
+      .sys_exit_execve_kretprobe
+      .set_autoload(false);
+    open_skel
+      .progs
+      .sys_exit_execveat_kretprobe
+      .set_autoload(false);
+
+    if can_i_use_sleepable_fentry(KCONFIG.as_ref(), None) {
+      rodata.tracexec_config.sleepable = MaybeUninit::new(true);
+      open_skel.progs.sys_execve_fentry.set_flags(BPF_F_SLEEPABLE);
+      open_skel
+        .progs
+        .sys_execveat_fentry
+        .set_flags(BPF_F_SLEEPABLE);
+      #[cfg(target_arch = "x86_64")]
+      {
+        open_skel.progs.compat_sys_execve.set_flags(BPF_F_SLEEPABLE);
+        open_skel
+          .progs
+          .compat_sys_execveat
+          .set_flags(BPF_F_SLEEPABLE);
+      }
+    }
+  }
+
+  if !kernel_have_syscall_wrappers(KCONFIG.as_ref()) {
+    open_skel.progs.sys_execve_kprobe.set_autoattach(false);
+    open_skel.progs.sys_execveat_kprobe.set_autoattach(false);
+    open_skel
+      .progs
+      .sys_exit_execve_kretprobe
+      .set_autoattach(false);
+    open_skel
+      .progs
+      .sys_exit_execveat_kretprobe
+      .set_autoattach(false);
+  }
+
+  let cache_size: u32 = (2 * num_possible_cpus()?)
+    .try_into()
+    .map_err(|_| eyre!("too many possible CPUs"))?;
+  open_skel.maps.cache.set_max_entries(cache_size)?;
+
+  Ok(())
+}
+
+fn prepare_trace_fork(open_skel: &mut OpenTracexecSystemSkel<'_>) -> Result<()> {
+  let _ = prepare_trace_fork_only(open_skel);
+  Ok(())
+}
+
+fn prepare_process_free(open_skel: &mut OpenTracexecSystemSkel<'_>) -> Result<()> {
+  disable_all_programs(open_skel);
+  open_skel.progs.handle_process_free.set_autoload(true);
+  open_skel.progs.handle_process_free.set_autoattach(true);
+  if let Some(rodata) = open_skel.maps.rodata_data.as_deref_mut() {
+    rodata.tracexec_config.follow_fork = MaybeUninit::new(true);
+  }
+  Ok(())
+}
+
+fn prepare_handle_exit(open_skel: &mut OpenTracexecSystemSkel<'_>) -> Result<()> {
+  let _ = prepare_handle_exit_only(open_skel);
+  Ok(())
+}
+
+fn prepare_execve_kprobe(open_skel: &mut OpenTracexecSystemSkel<'_>) -> Result<()> {
+  let _ = prepare_execve_kprobe_kretprobe(open_skel);
+  Ok(())
+}
+
+fn prepare_execveat_kprobe(open_skel: &mut OpenTracexecSystemSkel<'_>) -> Result<()> {
+  let _ = prepare_execveat_kprobe_kretprobe(open_skel);
+  Ok(())
+}
+
+fn prepare_execve_fentry(open_skel: &mut OpenTracexecSystemSkel<'_>) -> Result<()> {
+  let _ = prepare_execve_fentry_fexit(open_skel);
+  Ok(())
+}
+
+fn prepare_execveat_fentry(open_skel: &mut OpenTracexecSystemSkel<'_>) -> Result<()> {
+  let _ = prepare_execveat_fentry_fexit(open_skel);
+  Ok(())
+}
+
+#[cfg(target_arch = "x86_64")]
+fn prepare_compat_execve_fentry(open_skel: &mut OpenTracexecSystemSkel<'_>) -> Result<()> {
+  use tracexec_backend_ebpf::test_utils::prepare_compat_execve;
+
+  let _ = prepare_compat_execve(open_skel);
+  Ok(())
+}
+
+#[cfg(target_arch = "x86_64")]
+fn prepare_compat_execveat_fentry(open_skel: &mut OpenTracexecSystemSkel<'_>) -> Result<()> {
+  use tracexec_backend_ebpf::test_utils::prepare_compat_execveat;
+
+  let _ = prepare_compat_execveat(open_skel);
+  Ok(())
+}

--- a/crates/tracexec-backend-ebpf/src/bin/verifier_complexity.rs
+++ b/crates/tracexec-backend-ebpf/src/bin/verifier_complexity.rs
@@ -78,6 +78,7 @@ struct VerifierMetrics {
   peak_states: u64,
   mark_read: u64,
   verification_time_microseconds: Option<u64>,
+  stack_depth: Option<u64>,
   stack_depths: Vec<u64>,
 }
 
@@ -279,7 +280,6 @@ fn run_case(
           text
         )
       })?;
-      let stack_depth = metrics.stack_depths.iter().copied().max();
       Ok(ComplexityRecord {
         collection: COLLECTION,
         build: build.to_string(),
@@ -294,7 +294,7 @@ fn run_case(
         peak_states: metrics.peak_states,
         mark_read: metrics.mark_read,
         verification_time_microseconds: metrics.verification_time_microseconds,
-        stack_depth,
+        stack_depth: metrics.stack_depth,
         stack_depths: metrics.stack_depths,
       })
     })
@@ -349,6 +349,7 @@ fn verifier_log_text(buf: &[u8]) -> String {
 
 fn parse_verifier_metrics(log: &str) -> Option<VerifierMetrics> {
   let mut verification_time_microseconds = None;
+  let mut stack_depth = None;
   let mut stack_depths = Vec::new();
   let mut processed = None;
 
@@ -359,12 +360,10 @@ fn parse_verifier_metrics(log: &str) -> Option<VerifierMetrics> {
     {
       verification_time_microseconds = value.parse().ok();
     } else if let Some(value) = line.strip_prefix("stack depth ") {
-      stack_depths = value
-        .split('+')
-        .filter(|part| !part.is_empty())
-        .map(str::parse)
-        .collect::<Result<Vec<_>, _>>()
-        .ok()?;
+      if let Some((depths, explicit_max)) = parse_stack_depth_line(value) {
+        stack_depth = explicit_max;
+        stack_depths = depths;
+      }
     } else if line.starts_with("processed ") {
       processed = Some(parse_processed_line(line)?);
     }
@@ -381,8 +380,32 @@ fn parse_verifier_metrics(log: &str) -> Option<VerifierMetrics> {
     peak_states,
     mark_read,
     verification_time_microseconds,
+    stack_depth,
     stack_depths,
   })
+}
+
+fn parse_stack_depth_line(line: &str) -> Option<(Vec<u64>, Option<u64>)> {
+  let mut parts = line.split_whitespace();
+  let depth_list = parts.next()?;
+  let depths = depth_list
+    .split('+')
+    .filter(|part| !part.is_empty())
+    .map(str::parse)
+    .collect::<Result<Vec<_>, _>>()
+    .ok()?;
+  if depths.is_empty() {
+    return None;
+  }
+
+  let mut explicit_max = None;
+  while let Some(part) = parts.next() {
+    if part == "max" {
+      explicit_max = parts.next().and_then(|value| value.parse().ok());
+    }
+  }
+
+  Some((depths, explicit_max))
 }
 
 fn parse_processed_line(line: &str) -> Option<(u64, u64, u64, u64, u64, u64)> {
@@ -539,4 +562,54 @@ fn prepare_compat_execveat_fentry(open_skel: &mut OpenTracexecSystemSkel<'_>) ->
 
   let _ = prepare_compat_execveat(open_skel);
   Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn parses_stack_depth_with_explicit_max() {
+    let metrics = parse_verifier_metrics(
+      "verification time 955 usec\n\
+       stack depth 24+16 max 48\n\
+       insns processed 96+7\n\
+       processed 103 insns (limit 1000000) max_states_per_insn 0 total_states 8 peak_states 8 mark_read 0\n",
+    )
+    .expect("metrics should parse");
+
+    assert_eq!(metrics.verification_time_microseconds, Some(955));
+    assert_eq!(metrics.stack_depth, Some(48));
+    assert_eq!(metrics.stack_depths, vec![24, 16]);
+    assert_eq!(metrics.insns_processed, 103);
+    assert_eq!(metrics.insns_limit, 1_000_000);
+    assert_eq!(metrics.total_states, 8);
+    assert_eq!(metrics.peak_states, 8);
+  }
+
+  #[test]
+  fn leaves_stack_depth_unset_without_explicit_max() {
+    let metrics = parse_verifier_metrics(
+      "verification time 10 usec\n\
+       stack depth 24+16\n\
+       processed 103 insns (limit 1000000) max_states_per_insn 0 total_states 8 peak_states 8 mark_read 0\n",
+    )
+    .expect("metrics should parse");
+
+    assert_eq!(metrics.stack_depth, None);
+    assert_eq!(metrics.stack_depths, vec![24, 16]);
+  }
+
+  #[test]
+  fn unknown_stack_depth_format_does_not_hide_processed_metrics() {
+    let metrics = parse_verifier_metrics(
+      "stack depth some future format\n\
+       processed 103 insns (limit 1000000) max_states_per_insn 0 total_states 8 peak_states 8 mark_read 0\n",
+    )
+    .expect("processed metrics should still parse");
+
+    assert_eq!(metrics.stack_depth, None);
+    assert!(metrics.stack_depths.is_empty());
+    assert_eq!(metrics.insns_processed, 103);
+  }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,23 @@
             ...
           }:
           let
+            plotVerifierComplexity = pkgs.writeShellApplication {
+              name = "plot-verifier-complexity";
+              runtimeInputs = [
+                (pkgs.python3.withPackages (pythonPackages: [
+                  pythonPackages.matplotlib
+                ]))
+              ];
+              text = ''
+                script="''${TRACEXEC_PLOT_VERIFIER_COMPLEXITY_SCRIPT:-scripts/plot-verifier-complexity.py}"
+                if [ ! -f "$script" ]; then
+                  echo "plot-verifier-complexity: could not find $script" >&2
+                  echo "run this from the tracexec repository root, or set TRACEXEC_PLOT_VERIFIER_COMPLEXITY_SCRIPT" >&2
+                  exit 1
+                fi
+                exec python3 "$script" "$@"
+              '';
+            };
             defaultShell = pkgs.mkShell {
               name = "Development Shell";
               packages =
@@ -66,6 +83,7 @@
           in
           {
             packages.default = self'.packages.tracexec;
+            packages.plot-verifier-complexity = plotVerifierComplexity;
             devShells.default = defaultShell;
             devShells.extended = pkgs.mkShell {
               inputsFrom = [ defaultShell ];

--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -161,7 +161,7 @@ localFlake:
                 kernelPatches = [ ];
                 extraMakeFlags = [ ];
               }
-            
+
               {
                 name = "7.2";
                 tag = "v7.2-rc1";
@@ -305,6 +305,50 @@ localFlake:
                   find "$out/target" -type d -empty -delete
                 '';
               };
+          tracexecEbpfVerifierComplexityForClang =
+            targetPkgs: llvmVer:
+            let
+              bpfClang = targetPkgs.buildPackages.${"llvmPackages_${toString llvmVer}"}.clang.cc;
+              cargoExtraArgs = "--locked --package tracexec-backend-ebpf --no-default-features -F verifier-complexity --bin tracexec-verifier-complexity";
+            in
+            (import ./tracexec-package.nix {
+              inherit (targetPkgs) lib;
+              inherit (localFlake) crane;
+              pkgs = targetPkgs;
+            })
+              {
+                inherit bpfClang;
+                pnameSuffix = "-ebpf-verifier-complexity";
+                inherit cargoExtraArgs;
+                cargoArtifacts = targetPkgs.runCommand "empty-cargo-target" { } "mkdir -p $out/target";
+                doCheck = false;
+                doNotPostBuildInstallCargoBinaries = true;
+                buildPhaseCargoCommand = ''
+                  mkdir -p "$out/target"
+                  export CARGO_TARGET_DIR="$out/target"
+                  cargoWithProfile build --message-format json-render-diagnostics ${cargoExtraArgs}
+                '';
+                installPhaseCommand = ''
+                  mkdir -p "$out/bin"
+
+                  found=0
+                  for candidate in \
+                    "$out"/target/*/release/tracexec-verifier-complexity \
+                    "$out"/target/release/tracexec-verifier-complexity
+                  do
+                    if [ -f "$candidate" ] && [ -x "$candidate" ]; then
+                      install -Dm755 "$candidate" "$out/bin/tracexec-verifier-complexity"
+                      found=$((found + 1))
+                    fi
+                  done
+                  if [ "$found" -ne 1 ]; then
+                    echo "expected exactly one tracexec-verifier-complexity binary, found $found" >&2
+                    exit 1
+                  fi
+
+                  rm -rf "$out/target"
+                '';
+              };
           # Build a single shared initramfs per target system (no kernel dependency)
           initramfsForTarget =
             targetSystem:
@@ -401,6 +445,7 @@ localFlake:
                   targetPkgs = pkgsForTarget builtKernel.targetSystem;
                   testPackage = tracexecForClang targetPkgs llvmVer;
                   rootTestsPackage = tracexecEbpfRootTestsForClang targetPkgs llvmVer;
+                  complexityPackage = tracexecEbpfVerifierComplexityForClang targetPkgs llvmVer;
                 in
                 {
                   inherit (builtKernel)
@@ -410,6 +455,7 @@ localFlake:
                     test_exe
                     ;
                   inherit rootTestsPackage testPackage;
+                  inherit complexityPackage;
                   name = "${builtKernel.baseName}-clang${toString llvmVer}";
                   initramfs = initramfsMap.${builtKernel.targetSystem};
                   xfail = false;
@@ -442,7 +488,9 @@ localFlake:
             let
               runQemuName = "run-qemu${nameSuffix}";
               testQemuName = "test-qemu${nameSuffix}";
+              testQemuComplexityName = "test-qemu-complexity${nameSuffix}";
               ukciName = "ukci${nameSuffix}";
+              ukciComplexityName = "ukci-complexity${nameSuffix}";
               shellCases = lib.concatMapStrings (
                 {
                   name,
@@ -470,6 +518,15 @@ localFlake:
                   ...
                 }:
                 "${name}:${targetSystem}:${test_exe}:${testPackage}:${rootTestsPackage}:${if xfail then "1" else "0"}"
+              ) kernels;
+              complexityPlatforms = lib.concatMapStringsSep " " (
+                {
+                  name,
+                  targetSystem,
+                  complexityPackage,
+                  ...
+                }:
+                "${name}:${targetSystem}:${complexityPackage}"
               ) kernels;
               defaultPackage = if kernels == [ ] then "" else (builtins.head kernels).testPackage;
               ukciSummaryHeader =
@@ -579,6 +636,34 @@ localFlake:
                 fi
                 ${pkgs.nix}/bin/nix copy --to ssh://root@127.0.0.1 "$package" "$root_tests_package"
                 $ssh "set -e; for test_bin in \"$root_tests_package\"/bin/*; do echo \"running \$(basename \"\$test_bin\")\"; \"\$test_bin\" --ignored --test-threads=1 --nocapture; done"
+              '';
+              testQemuComplexityDrv = pkgs.writeScriptBin testQemuComplexityName ''
+                #!/usr/bin/env sh
+                complexity_package="$1"
+                build_label="''${2:-manual}"
+                port="''${3:-${vmSshPort}}"
+                poweroff="''${4:-0}"
+                ssh="ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null root@127.0.0.1 -p $port"
+                if [ "$poweroff" = "1" ]; then
+                  cleanup() {
+                    $ssh poweroff -f >/dev/null 2>&1 || true
+                  }
+                  trap cleanup EXIT INT TERM
+                fi
+
+                for i in $(seq 1 100); do
+                  [ $i -gt 1 ] && sleep 5;
+                  $ssh true && break;
+                done;
+
+                $ssh uname -a >&2
+                export NIX_SSHOPTS="-p $port -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+                if [ -z "$complexity_package" ]; then
+                  echo "Missing eBPF verifier complexity package path!" >&2
+                  exit 1
+                fi
+                ${pkgs.nix}/bin/nix copy --to ssh://root@127.0.0.1 "$complexity_package" >&2
+                $ssh "TRACEXEC_VERIFIER_BUILD=\"$build_label\" \"$complexity_package\"/bin/tracexec-verifier-complexity"
               '';
               ukciDrv = pkgs.writeScriptBin ukciName ''
                 #!/usr/bin/env bash
@@ -752,11 +837,156 @@ localFlake:
                 rm -rf "$logs_dir" "$results_dir"
                 exit "$status"
               '';
+              ukciComplexityDrv = pkgs.writeScriptBin ukciComplexityName ''
+                #!/usr/bin/env bash
+
+                set -e
+
+                output_dir="''${UKCI_COMPLEXITY_OUT_DIR:-verifier-complexity}"
+                mkdir -p "$output_dir"
+                logs_dir="$(mktemp -d)"
+                results_dir="$(mktemp -d)"
+                lock_dir="$logs_dir/.lock"
+                status=0
+                running=0
+                if command -v nproc >/dev/null 2>&1; then
+                  max_parallel="''${UKCI_MAX_PARALLEL:-$(nproc)}"
+                else
+                  max_parallel="''${UKCI_MAX_PARALLEL:-$(getconf _NPROCESSORS_ONLN)}"
+                fi
+                if [ -z "$max_parallel" ] || [ "$max_parallel" -lt 1 ]; then
+                  max_parallel=1
+                fi
+                if [ -t 1 ]; then
+                  RED="$(printf '\033[31m')"
+                  GREEN="$(printf '\033[32m')"
+                  YELLOW="$(printf '\033[33m')"
+                  BLUE="$(printf '\033[34m')"
+                  BOLD="$(printf '\033[1m')"
+                  RESET="$(printf '\033[0m')"
+                else
+                  RED=""
+                  GREEN=""
+                  YELLOW=""
+                  BLUE=""
+                  BOLD=""
+                  RESET=""
+                fi
+
+                idx=0
+                for platform in ${complexityPlatforms}; do
+                  IFS=: read -r kernel target_system complexity_package <<< "$platform"
+                  port=$(( ${vmSshPort} + idx ))
+                  name="$kernel"
+                  qemu_log="$logs_dir/$name.qemu.log"
+                  complexity_log="$logs_dir/$name.complexity.log"
+                  json_tmp="$output_dir/$name.json.tmp"
+                  json_out="$output_dir/$name.json"
+                  (
+                    set +e
+                    ${runQemuDrv}/bin/${runQemuName} "$kernel" "$port" >"$qemu_log" 2>&1 &
+                    qemu_pid=$!
+                    ${pkgs.coreutils}/bin/timeout 900s \
+                      ${testQemuComplexityDrv}/bin/${testQemuComplexityName} "$complexity_package" "$name" "$port" "1" >"$json_tmp" 2>"$complexity_log"
+                    test_status=$?
+                    if kill -0 "$qemu_pid" >/dev/null 2>&1; then
+                      kill "$qemu_pid" >/dev/null 2>&1 || true
+                    fi
+                    wait "$qemu_pid" 2>/dev/null || true
+                    while ! mkdir "$lock_dir" 2>/dev/null; do
+                      sleep 0.1
+                    done
+                    echo "''${BLUE}''${BOLD}===> $name (qemu)''${RESET}"
+                    cat "$qemu_log" || true
+                    echo "''${BLUE}''${BOLD}===> $name (complexity)''${RESET}"
+                    cat "$complexity_log" || true
+                    if [ "$test_status" -eq 0 ]; then
+                      mv "$json_tmp" "$json_out"
+                      result_label="PASS"
+                      count="$(grep -c '"program"' "$json_out" || true)"
+                      echo "''${GREEN}''${BOLD}PASS:''${RESET} ''${name} wrote ''${count} records to $json_out"
+                    elif [ "$test_status" -eq 124 ] || [ "$test_status" -eq 137 ]; then
+                      rm -f "$json_tmp"
+                      result_label="TIMEOUT"
+                      echo "''${RED}''${BOLD}FAIL:''${RESET} ''${name} timed out after 900s"
+                    else
+                      rm -f "$json_tmp"
+                      result_label="FAIL ($test_status)"
+                      echo "''${RED}''${BOLD}FAIL:''${RESET} ''${name} exited with status ''${test_status}"
+                    fi
+                    printf '%s\n' "$result_label" > "$results_dir/$name"
+                    rmdir "$lock_dir"
+                    rm -f "$qemu_log" "$complexity_log"
+                    exit "$test_status"
+                  ) &
+                  running=$(( running + 1 ))
+                  if [ "$running" -ge "$max_parallel" ]; then
+                    if ! wait -n; then
+                      status=1
+                    fi
+                    running=$(( running - 1 ))
+                  fi
+                  idx=$(( idx + 1 ))
+                done
+
+                while [ "$running" -gt 0 ]; do
+                  if ! wait -n; then
+                    status=1
+                  fi
+                  running=$(( running - 1 ))
+                done
+
+                summary_title="''${UKCI_SUMMARY_TITLE:-UKCI eBPF verifier complexity}"
+                render_summary_table() {
+                  echo "## $summary_title"
+                  echo ""
+                  echo "${ukciSummaryHeader}"
+                  echo "${ukciSummarySep}"
+                  declare -A seen_row=
+                  row_order=()
+                  for platform in ${complexityPlatforms}; do
+                    IFS=: read -r pname _ts _pkg <<< "$platform"
+                    row_key="''${pname%-clang*}"
+                    if [ -z "''${seen_row[$row_key]+x}" ]; then
+                      seen_row[$row_key]=1
+                      row_order+=("$row_key")
+                    fi
+                  done
+                  for row_key in "''${row_order[@]}"; do
+                    line="| $row_key |"
+                    for llvm_ver in ${llvmVersionsSpaceSep}; do
+                      cell_name="$row_key-clang$llvm_ver"
+                      f="$results_dir/$cell_name"
+                      if [ -f "$f" ]; then
+                        cell="$(cat "$f")"
+                      else
+                        cell="—"
+                      fi
+                      line="$line $cell |"
+                    done
+                    echo "$line"
+                  done
+                  echo ""
+                  echo "JSON output directory: $output_dir"
+                  echo ""
+                }
+                set +e
+                render_summary_table
+                if [ -n "''${GITHUB_STEP_SUMMARY:-}" ]; then
+                  render_summary_table >> "$GITHUB_STEP_SUMMARY"
+                fi
+                set -e
+
+                rm -rf "$logs_dir" "$results_dir"
+                exit "$status"
+              '';
             in
             {
               run-qemu = runQemuDrv;
               test-qemu = testQemuDrv;
+              test-qemu-complexity = testQemuComplexityDrv;
               ukci = ukciDrv;
+              ukci-complexity = ukciComplexityDrv;
             };
           nativeScripts = mkScripts {
             kernels = kernelsNative;
@@ -788,7 +1018,9 @@ localFlake:
             lib.listToAttrs [
               (lib.nameValuePair "run-qemu-${attrSuffix}" scripts.run-qemu)
               (lib.nameValuePair "test-qemu-${attrSuffix}" scripts.test-qemu)
+              (lib.nameValuePair "test-qemu-complexity-${attrSuffix}" scripts.test-qemu-complexity)
               (lib.nameValuePair "ukci-${attrSuffix}" scripts.ukci)
+              (lib.nameValuePair "ukci-complexity-${attrSuffix}" scripts.ukci-complexity)
             ];
           perTargetScripts = lib.foldl' lib.recursiveUpdate { } (
             map (targetSystem: mkTargetScriptAttrs { inherit targetSystem; }) targetSystemsAll
@@ -804,8 +1036,16 @@ localFlake:
           );
         in
         rec {
-          inherit (nativeScripts) run-qemu test-qemu ukci;
+          inherit (nativeScripts)
+            run-qemu
+            test-qemu
+            test-qemu-complexity
+            ukci
+            ukci-complexity
+            ;
           ukci-latest-llvm = nativeScriptsLatest.ukci;
+          ukci-complexity-latest-llvm = nativeScriptsLatest.ukci-complexity;
+          test-qemu-complexity-latest-llvm = nativeScriptsLatest.test-qemu-complexity;
         }
         // perTargetScripts
         // perTargetScriptsLatest;

--- a/scripts/plot-verifier-complexity.py
+++ b/scripts/plot-verifier-complexity.py
@@ -140,15 +140,6 @@ def parse_metrics(value: str) -> list[str]:
 def record_metric(record: dict[str, Any], metric: str) -> float | None:
     value = record.get(metric)
 
-    if value is None and metric == "stack_depth":
-        depths = record.get("stack_depths")
-        if isinstance(depths, list):
-            values = [number(depth) for depth in depths]
-            values = [
-                depth for depth in values if depth is not None and math.isfinite(depth)
-            ]
-            return max(values) if values else None
-
     result = number(value)
     return result if result is not None and math.isfinite(result) else None
 

--- a/scripts/plot-verifier-complexity.py
+++ b/scripts/plot-verifier-complexity.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""Plot tracexec eBPF verifier complexity results.
+
+The input is one or more JSON files produced by tracexec-verifier-complexity,
+or directories containing those files. The script writes heatmaps, max-by-build
+charts, and a small Markdown/CSV summary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import re
+import sys
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_INPUT = Path("verifier-complexity")
+DEFAULT_OUTPUT = Path("verifier-complexity-plots")
+DEFAULT_METRICS = (
+    "insns_processed",
+    "verification_time_microseconds",
+    "peak_states",
+    "stack_depth",
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Plot verifier complexity JSON files produced by UKCI complexity runs."
+    )
+    parser.add_argument(
+        "inputs",
+        nargs="*",
+        type=Path,
+        default=[DEFAULT_INPUT],
+        help="JSON files or directories containing JSON files (default: verifier-complexity)",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT,
+        help="directory for charts and summaries (default: verifier-complexity-plots)",
+    )
+    parser.add_argument(
+        "--metrics",
+        default=",".join(DEFAULT_METRICS),
+        help="comma-separated metrics to plot",
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=25,
+        help="number of load/program rows to include in each heatmap (default: 25)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("png", "pdf", "svg"),
+        default="png",
+        help="plot output format (default: png)",
+    )
+    parser.add_argument(
+        "--dpi",
+        type=int,
+        default=160,
+        help="raster plot DPI for PNG output (default: 160)",
+    )
+    parser.add_argument(
+        "--log-scale",
+        action="store_true",
+        help="use logarithmic color scale for heatmaps",
+    )
+    parser.add_argument(
+        "--no-plots",
+        action="store_true",
+        help="write only summary files; useful when matplotlib is unavailable",
+    )
+    return parser.parse_args()
+
+
+def find_json_files(inputs: Iterable[Path]) -> list[Path]:
+    files: list[Path] = []
+    for input_path in inputs:
+        if input_path.is_dir():
+            files.extend(
+                path
+                for path in sorted(input_path.rglob("*.json"))
+                if not path.name.endswith(".tmp")
+            )
+        elif input_path.is_file():
+            files.append(input_path)
+        else:
+            raise FileNotFoundError(f"input does not exist: {input_path}")
+
+    if not files:
+        raise FileNotFoundError("no JSON files found in the requested inputs")
+    return files
+
+
+def load_records(files: Iterable[Path]) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for path in files:
+        with path.open(encoding="utf-8") as handle:
+            data = json.load(handle)
+
+        if isinstance(data, dict) and isinstance(data.get("records"), list):
+            file_records = data["records"]
+        elif isinstance(data, list):
+            file_records = data
+        else:
+            raise ValueError(f"{path}: expected a JSON array or an object with a records array")
+
+        for index, record in enumerate(file_records):
+            if not isinstance(record, dict):
+                raise ValueError(f"{path}: record {index} is not an object")
+            for field in ("build", "load", "program"):
+                if field not in record:
+                    raise ValueError(f"{path}: record {index} is missing {field!r}")
+            loaded = dict(record)
+            loaded["_source_file"] = str(path)
+            records.append(loaded)
+
+    if not records:
+        raise ValueError("no verifier complexity records found")
+    return records
+
+
+def parse_metrics(value: str) -> list[str]:
+    metrics = [metric.strip() for metric in value.split(",") if metric.strip()]
+    if not metrics:
+        raise ValueError("at least one metric is required")
+    return metrics
+
+
+def record_metric(record: dict[str, Any], metric: str) -> float | None:
+    value = record.get(metric)
+
+    if value is None and metric == "stack_depth":
+        depths = record.get("stack_depths")
+        if isinstance(depths, list):
+            values = [number(depth) for depth in depths]
+            values = [
+                depth for depth in values if depth is not None and math.isfinite(depth)
+            ]
+            return max(values) if values else None
+
+    result = number(value)
+    return result if result is not None and math.isfinite(result) else None
+
+
+def number(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def load_program_key(record: dict[str, Any]) -> str:
+    return f"{record['load']}/{record['program']}"
+
+
+def natural_key(value: str) -> list[int | str]:
+    return [
+        int(part) if part.isdigit() else part
+        for part in re.split(r"(\d+)", value)
+        if part != ""
+    ]
+
+
+def slug(value: str) -> str:
+    return re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-").lower()
+
+
+def metric_label(metric: str) -> str:
+    return metric.replace("_", " ")
+
+
+def format_number(value: float | None) -> str:
+    if value is None or math.isnan(value):
+        return ""
+    if value.is_integer():
+        return f"{int(value):,}"
+    return f"{value:,.2f}"
+
+
+def markdown_cell(value: Any) -> str:
+    return str(value).replace("|", "\\|")
+
+
+def records_for_metric(
+    records: Iterable[dict[str, Any]], metric: str
+) -> list[tuple[float, dict[str, Any]]]:
+    rows = []
+    for record in records:
+        value = record_metric(record, metric)
+        if value is not None:
+            rows.append((value, record))
+    rows.sort(key=lambda row: row[0], reverse=True)
+    return rows
+
+
+def write_summary(
+    output_dir: Path,
+    records: list[dict[str, Any]],
+    files: list[Path],
+    metrics: list[str],
+    top: int,
+) -> None:
+    builds = sorted({str(record["build"]) for record in records}, key=natural_key)
+    load_programs = sorted({load_program_key(record) for record in records}, key=natural_key)
+
+    summary_path = output_dir / "summary.md"
+    with summary_path.open("w", encoding="utf-8") as handle:
+        handle.write("# Verifier Complexity Summary\n\n")
+        handle.write(f"- Records: {len(records):,}\n")
+        handle.write(f"- Input files: {len(files):,}\n")
+        handle.write(f"- Builds: {len(builds):,}\n")
+        handle.write(f"- Load/program pairs: {len(load_programs):,}\n\n")
+
+        handle.write("## Builds\n\n")
+        for build in builds:
+            releases = sorted(
+                {
+                    str(record.get("kernel_release", "unknown"))
+                    for record in records
+                    if record["build"] == build
+                },
+                key=natural_key,
+            )
+            release_text = ", ".join(releases)
+            handle.write(f"- `{build}` ({release_text})\n")
+
+        for metric in metrics:
+            rows = records_for_metric(records, metric)
+            if not rows:
+                continue
+
+            handle.write(f"\n## Top {metric_label(metric)}\n\n")
+            handle.write("| value | build | load | program | kernel |\n")
+            handle.write("| ---: | --- | --- | --- | --- |\n")
+            for value, record in rows[:top]:
+                handle.write(
+                    "| "
+                    f"{format_number(value)} | "
+                    f"`{markdown_cell(record['build'])}` | "
+                    f"`{markdown_cell(record['load'])}` | "
+                    f"`{markdown_cell(record['program'])}` | "
+                    f"`{markdown_cell(record.get('kernel_release', ''))}` |\n"
+                )
+
+    csv_path = output_dir / "top-records.csv"
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "metric",
+                "rank",
+                "value",
+                "build",
+                "load",
+                "program",
+                "kernel_release",
+                "arch",
+                "source_file",
+            ],
+        )
+        writer.writeheader()
+        for metric in metrics:
+            for rank, (value, record) in enumerate(
+                records_for_metric(records, metric)[:top], start=1
+            ):
+                writer.writerow(
+                    {
+                        "metric": metric,
+                        "rank": rank,
+                        "value": int(value) if value.is_integer() else value,
+                        "build": record["build"],
+                        "load": record["load"],
+                        "program": record["program"],
+                        "kernel_release": record.get("kernel_release", ""),
+                        "arch": record.get("arch", ""),
+                        "source_file": record.get("_source_file", ""),
+                    }
+                )
+
+
+def require_plotting_modules() -> tuple[Any, Any, Any]:
+    try:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import numpy as np
+        from matplotlib import colors
+    except ImportError as error:
+        raise RuntimeError(
+            "matplotlib is required to render plots. "
+            "Run with Nix using: nix run .#plot-verifier-complexity -- verifier-complexity"
+        ) from error
+
+    return plt, np, colors
+
+
+def metric_matrix(
+    records: list[dict[str, Any]],
+    metric: str,
+    top: int,
+) -> tuple[list[str], list[str], list[list[float]]]:
+    cell_values: dict[tuple[str, str], float] = {}
+    max_by_key: dict[str, float] = {}
+    builds = sorted({str(record["build"]) for record in records}, key=natural_key)
+
+    for record in records:
+        value = record_metric(record, metric)
+        if value is None:
+            continue
+
+        key = load_program_key(record)
+        build = str(record["build"])
+        cell = (key, build)
+        cell_values[cell] = max(value, cell_values.get(cell, float("-inf")))
+        max_by_key[key] = max(value, max_by_key.get(key, float("-inf")))
+
+    keys = [
+        key
+        for key, _ in sorted(
+            max_by_key.items(), key=lambda item: (-item[1], natural_key(item[0]))
+        )[:top]
+    ]
+    matrix = [
+        [cell_values.get((key, build), math.nan) for build in builds]
+        for key in keys
+    ]
+    return keys, builds, matrix
+
+
+def plot_heatmap(
+    plt: Any,
+    np: Any,
+    colors: Any,
+    output_dir: Path,
+    records: list[dict[str, Any]],
+    metric: str,
+    top: int,
+    output_format: str,
+    dpi: int,
+    log_scale: bool,
+) -> Path | None:
+    keys, builds, matrix = metric_matrix(records, metric, top)
+    if not keys:
+        return None
+
+    values = np.array(matrix, dtype=float)
+    masked_values = np.ma.masked_invalid(values)
+    cmap = plt.get_cmap("viridis").copy()
+    cmap.set_bad("#f2f2f2")
+
+    positive_values = values[np.isfinite(values) & (values > 0)]
+    norm = None
+    if log_scale:
+        masked_values = np.ma.masked_where(values <= 0, masked_values)
+        if positive_values.size > 0:
+            min_value = float(positive_values.min())
+            max_value = float(positive_values.max())
+            if min_value < max_value:
+                norm = colors.LogNorm(vmin=min_value, vmax=max_value)
+
+    width = max(8.0, 0.55 * len(builds) + 3.0)
+    height = max(5.0, 0.34 * len(keys) + 2.0)
+    fig, ax = plt.subplots(figsize=(width, height))
+    image = ax.imshow(masked_values, aspect="auto", cmap=cmap, norm=norm)
+
+    ax.set_title(f"Top {len(keys)} {metric_label(metric)} values by load/program")
+    ax.set_xlabel("build")
+    ax.set_ylabel("load/program")
+    ax.set_xticks(range(len(builds)), labels=builds, rotation=45, ha="right")
+    ax.set_yticks(range(len(keys)), labels=keys)
+    ax.tick_params(axis="both", labelsize=8)
+    fig.colorbar(image, ax=ax, label=metric_label(metric))
+    fig.tight_layout()
+
+    path = output_dir / f"{slug(metric)}-heatmap.{output_format}"
+    fig.savefig(path, dpi=dpi)
+    plt.close(fig)
+    return path
+
+
+def plot_max_by_build(
+    plt: Any,
+    output_dir: Path,
+    records: list[dict[str, Any]],
+    metric: str,
+    output_format: str,
+    dpi: int,
+) -> Path | None:
+    max_by_build: dict[str, float] = {}
+    for record in records:
+        value = record_metric(record, metric)
+        if value is None:
+            continue
+        build = str(record["build"])
+        max_by_build[build] = max(value, max_by_build.get(build, float("-inf")))
+
+    if not max_by_build:
+        return None
+
+    builds = sorted(max_by_build, key=natural_key)
+    values = [max_by_build[build] for build in builds]
+
+    width = max(8.0, 0.55 * len(builds) + 3.0)
+    fig, ax = plt.subplots(figsize=(width, 5.0))
+    ax.bar(range(len(builds)), values, color="#3b728f")
+    ax.set_title(f"Maximum {metric_label(metric)} by build")
+    ax.set_xlabel("build")
+    ax.set_ylabel(metric_label(metric))
+    ax.set_xticks(range(len(builds)), labels=builds, rotation=45, ha="right")
+    ax.tick_params(axis="x", labelsize=8)
+    ax.yaxis.grid(True, linestyle=":", alpha=0.45)
+    ax.set_axisbelow(True)
+    fig.tight_layout()
+
+    path = output_dir / f"{slug(metric)}-max-by-build.{output_format}"
+    fig.savefig(path, dpi=dpi)
+    plt.close(fig)
+    return path
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        metrics = parse_metrics(args.metrics)
+        if args.top < 1:
+            raise ValueError("--top must be at least 1")
+
+        files = find_json_files(args.inputs)
+        records = load_records(files)
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        write_summary(args.output_dir, records, files, metrics, args.top)
+
+        written_plots: list[Path] = []
+        if not args.no_plots:
+            plt, np, colors = require_plotting_modules()
+            for metric in metrics:
+                heatmap = plot_heatmap(
+                    plt,
+                    np,
+                    colors,
+                    args.output_dir,
+                    records,
+                    metric,
+                    args.top,
+                    args.format,
+                    args.dpi,
+                    args.log_scale,
+                )
+                max_by_build = plot_max_by_build(
+                    plt,
+                    args.output_dir,
+                    records,
+                    metric,
+                    args.format,
+                    args.dpi,
+                )
+                written_plots.extend(path for path in (heatmap, max_by_build) if path)
+
+        print(f"wrote summary: {args.output_dir / 'summary.md'}")
+        print(f"wrote CSV: {args.output_dir / 'top-records.csv'}")
+        if written_plots:
+            print(f"wrote plots: {len(written_plots)}")
+        elif args.no_plots:
+            print("plots skipped")
+        else:
+            print("no metric values were available to plot")
+        return 0
+    except (OSError, ValueError, json.JSONDecodeError, RuntimeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Let's track the complexity of eBPF progs across supported kernel versions.

<img width="2064" height="1680" alt="image" src="https://github.com/user-attachments/assets/ba193e9d-be4a-45f1-8354-5c1ff5aded75" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional eBPF “verifier complexity” analysis run across kernels and LLVM versions, producing per-kernel/LLVM JSON metrics.
  - Added a Nix runner to execute the analysis in QEMU and a separate runner to plot and summarize results (including optional heatmaps).
  - Introduced a new feature-gated complexity data collector and aggregation output.
- **Documentation**
  - Documented the new analysis and plotting workflows, including output locations and comparison options.
- **Tests**
  - Added coverage for verifier stack-depth log parsing.
- **Chores**
  - Updated repository ignore rules for complexity outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->