### PR TITLE
chore: update UKCI kernels

### DIFF
--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -164,11 +164,11 @@ localFlake:
 
               {
                 name = "7.2";
-                tag = "v7.2-rc2";
-                version = "7.2.0-rc2";
+                tag = "v7.2-rc3";
+                version = "7.2.0-rc3";
                 source = "torvalds";
                 test_exe = "tracexec";
-                sha256 = "sha256-HsfZTdYNxjJczbeZfzFz6rSeFNJiokhrmAKKociSbOY=";
+                sha256 = "sha256-PyOZblLbx6jYqHKcYGd1p72OH1GUZyCGtvOBEhdC4L0=";
                 kernelPatches = [ ];
                 extraMakeFlags = [ ];
               }


### PR DESCRIPTION
Automated UKCI kernel update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Linux 7.2 release candidate from RC2 to RC3.
  * Refreshed the associated source verification checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->