### PR TITLE
feat(tui): add option to copy space-joined argv

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -150,6 +150,7 @@
 # copy_target_env = "e"
 # copy_target_env_diff = "d"
 # copy_target_argv = "a"
+# copy_target_argv_joined = "w"
 # copy_target_filename = "n"
 # copy_target_syscall_result = "r"
 # copy_target_line = "l"

--- a/crates/tracexec-core/src/cli/keys.rs
+++ b/crates/tracexec-core/src/cli/keys.rs
@@ -236,6 +236,7 @@ pub struct TuiKeyBindingsConfig {
   pub copy_target_env: Option<KeyList>,
   pub copy_target_env_diff: Option<KeyList>,
   pub copy_target_argv: Option<KeyList>,
+  pub copy_target_argv_joined: Option<KeyList>,
   pub copy_target_filename: Option<KeyList>,
   pub copy_target_syscall_result: Option<KeyList>,
   pub copy_target_line: Option<KeyList>,
@@ -322,6 +323,7 @@ pub struct TuiKeyBindings {
   pub copy_target_env: KeyList,
   pub copy_target_env_diff: KeyList,
   pub copy_target_argv: KeyList,
+  pub copy_target_argv_joined: KeyList,
   pub copy_target_filename: KeyList,
   pub copy_target_syscall_result: KeyList,
   pub copy_target_line: KeyList,
@@ -426,6 +428,7 @@ impl Default for TuiKeyBindings {
       copy_target_env: KeyList(vec![KeyBinding::char('e')]),
       copy_target_env_diff: KeyList(vec![KeyBinding::char('d')]),
       copy_target_argv: KeyList(vec![KeyBinding::char('a')]),
+      copy_target_argv_joined: KeyList(vec![KeyBinding::char('w')]),
       copy_target_filename: KeyList(vec![KeyBinding::char('n')]),
       copy_target_syscall_result: KeyList(vec![KeyBinding::char('r')]),
       copy_target_line: KeyList(vec![KeyBinding::char('l')]),
@@ -548,6 +551,7 @@ impl TuiKeyBindings {
       copy_target_env,
       copy_target_env_diff,
       copy_target_argv,
+      copy_target_argv_joined,
       copy_target_filename,
       copy_target_syscall_result,
       copy_target_line,
@@ -799,5 +803,13 @@ mod tests {
       .unwrap()
       .keys;
     assert_eq!(list.0.len(), 2);
+  }
+
+  #[test]
+  fn test_configure_whitespace_joined_argv_copy_target() {
+    let config: TuiKeyBindingsConfig = toml::from_str(r#"copy_target_argv_joined = "x""#).unwrap();
+    let keys = TuiKeyBindings::from_config(Some(Box::new(config)));
+
+    assert_eq!(keys.copy_target_argv_joined.0, vec![KeyBinding::char('x')]);
   }
 }

--- a/crates/tracexec-core/src/copy.rs
+++ b/crates/tracexec-core/src/copy.rs
@@ -29,6 +29,7 @@ pub enum CopyTarget {
   CommandlineWithFds(SupportedShell),
   Env,
   Argv,
+  ArgvJoined,
   Filename,
   SyscallResult,
   EnvDiff,
@@ -371,6 +372,10 @@ pub fn text_for_copy<'a>(
       result.into()
     }
     CopyTarget::Argv => TracerEventDetails::argv_to_string(&event.argv).into(),
+    CopyTarget::ArgvJoined => match event.argv.as_ref() {
+      Ok(argv) => argv.iter().map(AsRef::as_ref).join(" ").into(),
+      Err(_) => "[failed to read argv]".into(),
+    },
     CopyTarget::Filename => Cow::Borrowed(event.filename.as_ref()),
     CopyTarget::SyscallResult => event.result.to_string().into(),
     CopyTarget::Line => panic!("CopyTarget::Line requires a presentation formatter"),

--- a/crates/tracexec-tui/src/copy_popup.rs
+++ b/crates/tracexec-tui/src/copy_popup.rs
@@ -107,6 +107,12 @@ const COPY_TARGETS: &[CopyTargetConfig] = &[
     help_label: "Argv",
   },
   CopyTargetConfig {
+    target: CopyTarget::ArgvJoined,
+    default_key: 'w',
+    list_label: "Arguments joined by (W)hitespace",
+    help_label: "Whitespace-joined argv",
+  },
+  CopyTargetConfig {
     target: CopyTarget::Filename,
     default_key: 'n',
     list_label: "File(N)ame",
@@ -245,6 +251,7 @@ fn copy_target_binding(
     CopyTarget::Env => &keys.copy_target_env,
     CopyTarget::EnvDiff => &keys.copy_target_env_diff,
     CopyTarget::Argv => &keys.copy_target_argv,
+    CopyTarget::ArgvJoined => &keys.copy_target_argv_joined,
     CopyTarget::Filename => &keys.copy_target_filename,
     CopyTarget::SyscallResult => &keys.copy_target_syscall_result,
     CopyTarget::Line => &keys.copy_target_line,

--- a/crates/tracexec-tui/src/event.rs
+++ b/crates/tracexec-tui/src/event.rs
@@ -692,6 +692,15 @@ mod tests {
     assert_eq!(
       event.text_for_copy(
         &baseline,
+        CopyTarget::ArgvJoined,
+        &modifier,
+        RuntimeModifier::default()
+      ),
+      "custom-argv0 hello world"
+    );
+    assert_eq!(
+      event.text_for_copy(
+        &baseline,
         CopyTarget::Filename,
         &modifier,
         RuntimeModifier::default()
@@ -725,6 +734,15 @@ mod tests {
           RuntimeModifier::default()
         )
         .contains("failed to read argv")
+    );
+    assert_eq!(
+      failing.text_for_copy(
+        &baseline,
+        CopyTarget::ArgvJoined,
+        &modifier,
+        RuntimeModifier::default()
+      ),
+      "[failed to read argv]"
     );
     assert!(
       failing


### PR DESCRIPTION
This PR adds traditional execsnoop-style output as an option to the copy dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a copy option that joins a command’s arguments into a single space-separated line.
  * Added a configurable keyboard shortcut for this copy option, using `w` by default.
  * The new option is available in the copy selection menu.

* **Bug Fixes**
  * Displays a clear message when command arguments cannot be read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->