### PR TITLE
fix(ptrace): handle duplicated syscall exit stops with restarted sysc…

### DIFF
--- a/crates/tracexec-backend-ptrace/src/ptrace/syscall.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace/syscall.rs
@@ -43,6 +43,13 @@ pub struct SyscallInfo {
 }
 
 impl SyscallInfo {
+  pub fn is_entry(&self) -> bool {
+    matches!(
+      self.data,
+      SyscallInfoData::Entry { .. } | SyscallInfoData::Seccomp { .. }
+    )
+  }
+
   pub fn arch(&self) -> AuditArch {
     self.arch
   }

--- a/crates/tracexec-backend-ptrace/src/ptrace/tracer.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace/tracer.rs
@@ -272,6 +272,19 @@ impl Tracer {
     };
     Ok((running_tracer, tracer_thread))
   }
+
+  #[cfg(test)]
+  fn attach_for_test(self, pid: Pid) -> tokio::task::JoinHandle<color_eyre::Result<()>> {
+    let tx = self.msg_tx.clone();
+    tokio::task::spawn_blocking(move || {
+      let inner = TracerInner::new(self, Arc::new(RwLock::new(BTreeMap::new())), None)?;
+      let result = inner.run_attached(pid);
+      if let Err(e) = &result {
+        let _ = tx.send(TracerMessage::FatalError(e.to_string()));
+      }
+      result
+    })
+  }
 }
 
 static BREAKPOINT_ID: AtomicU32 = AtomicU32::new(0);

--- a/crates/tracexec-backend-ptrace/src/ptrace/tracer/inner.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace/tracer/inner.rs
@@ -160,6 +160,7 @@ use crate::{
       read_env,
       read_string,
     },
+    syscall::SyscallInfo,
     tracer::{
       PendingRequest,
       state::{
@@ -447,6 +448,39 @@ impl TracerInner {
       }
     }
   }
+
+  #[cfg(test)]
+  pub(super) fn run_attached(self, root_child: Pid) -> color_eyre::Result<()> {
+    use nix::sys::ptrace::Options;
+
+    let mut engine = RecursivePtraceEngine::new(self.seccomp_bpf());
+    engine.seize_children_recursive(
+      root_child,
+      Options::PTRACE_O_TRACEEXEC | Options::PTRACE_O_EXITKILL | Options::PTRACE_O_TRACESYSGOOD,
+    )?;
+    // Consume the real restart entry produced by attaching to a blocked
+    // syscall.  The regular event loop then starts with that syscall already
+    // in flight, so its first syscall stop must be dispatched as an exit.
+    let guard = match engine.next_event(None)? {
+      PtraceWaitPidEvent::Ptrace(PtraceStopGuard::Syscall(guard)) => guard,
+      event => panic!("expected syscall entry stop after attach, got {event:?}"),
+    };
+    assert!(guard.syscall_info()?.is_entry());
+    guard.cont_syscall(false)?;
+
+    let mut root_child_state = ProcessState::new(root_child)?;
+    root_child_state.ppid = Some(getpid());
+    self.store.borrow_mut().insert(root_child_state);
+
+    let mut pending_guards = HashMap::new();
+    loop {
+      match self.handle_waitpid_events(&engine, root_child, &mut pending_guards, true) {
+        Ok(ControlFlow::Break(_)) => return Ok(()),
+        Ok(ControlFlow::Continue(_)) | Err(WaitpidHandlerError::Interrupted) => {}
+        Err(e) => return Err(e.into()),
+      }
+    }
+  }
 }
 
 // Core loop
@@ -480,25 +514,27 @@ impl TracerInner {
       // trace!("waitpid: {:?}", status);
       match status {
         PtraceWaitPidEvent::Ptrace(PtraceStopGuard::Syscall(guard)) => {
-          let presyscall = self
-            .store
-            .borrow_mut()
-            .get_current_mut(guard.pid())
-            .unwrap()
-            .presyscall;
-          if presyscall {
+          // A restarted syscall can produce consecutive exit stops, so the
+          // kernel-reported stop kind is authoritative over `presyscall`.
+          let Some(info) = self.read_syscall_info(&guard).context(OtherSnafu)? else {
+            continue;
+          };
+          if info.is_entry() {
             self
-              .on_syscall_enter(Either::Left(guard), pending_guards, timestamp)
+              .on_syscall_enter(Either::Left(guard), info, pending_guards, timestamp)
               .context(OtherSnafu)?;
           } else {
             self
-              .on_syscall_exit(guard, pending_guards, timestamp)
+              .on_syscall_exit(guard, info, pending_guards, timestamp)
               .context(OtherSnafu)?;
           }
         }
         PtraceWaitPidEvent::Ptrace(PtraceStopGuard::Seccomp(guard)) => {
+          let Some(info) = self.read_syscall_info(&guard).context(OtherSnafu)? else {
+            continue;
+          };
           self
-            .on_syscall_enter(Either::Right(guard), pending_guards, timestamp)
+            .on_syscall_enter(Either::Right(guard), info, pending_guards, timestamp)
             .context(OtherSnafu)?;
         }
         PtraceWaitPidEvent::Ptrace(PtraceStopGuard::SignalDelivery(guard)) => {
@@ -785,20 +821,14 @@ impl TracerInner {
     Ok(ControlFlow::Continue(()))
   }
 
-  fn on_syscall_enter<'a>(
+  fn read_syscall_info(
     &self,
-    guard: Either<PtraceSyscallStopGuard<'a>, PtraceSeccompStopGuard<'a>>,
-    pending_guards: &mut HashMap<Pid, PtraceStopGuard<'a>>,
-    timestamp: DateTime<Local>,
-  ) -> color_eyre::Result<()> {
-    let pid = guard.pid();
-    let mut store = self.store.borrow_mut();
-    let p = store.get_current_mut(pid).unwrap();
-    p.presyscall = !p.presyscall;
-    // SYSCALL ENTRY
-    let info = match guard.syscall_info() {
-      Ok(info) => info,
+    guard: &impl PtraceSyscallLikeStop,
+  ) -> color_eyre::Result<Option<SyscallInfo>> {
+    match guard.syscall_info() {
+      Ok(info) => Ok(Some(info)),
       Err(Errno::ESRCH) => {
+        let pid = guard.pid();
         filterable_event!(Info(TracerEventMessage {
           timestamp: self.timestamp_now(),
           msg: "Failed to get syscall info: ESRCH (child probably gone!)".to_string(),
@@ -806,10 +836,25 @@ impl TracerInner {
         }))
         .send_if_match(&self.msg_tx, self.filter)?;
         info!("ptrace get_syscall_info failed: {pid}, ESRCH, child probably gone!");
-        return Ok(());
+        Ok(None)
       }
-      e => e?,
-    };
+      Err(error) => Err(error.into()),
+    }
+  }
+
+  fn on_syscall_enter<'a>(
+    &self,
+    guard: Either<PtraceSyscallStopGuard<'a>, PtraceSeccompStopGuard<'a>>,
+    info: SyscallInfo,
+    pending_guards: &mut HashMap<Pid, PtraceStopGuard<'a>>,
+    timestamp: DateTime<Local>,
+  ) -> color_eyre::Result<()> {
+    let pid = guard.pid();
+    let mut store = self.store.borrow_mut();
+    let p = store.get_current_mut(pid).unwrap();
+    p.presyscall = false;
+    // SYSCALL ENTRY
+    debug_assert!(info.is_entry());
     let regs = match guard.get_general_registers() {
       Ok(regs) => regs,
       Err(Errno::ESRCH) => {
@@ -986,6 +1031,7 @@ impl TracerInner {
   fn on_syscall_exit<'a>(
     &self,
     guard: PtraceSyscallStopGuard<'a>,
+    info: SyscallInfo,
     pending_guards: &mut HashMap<Pid, PtraceStopGuard<'a>>,
     timestamp: DateTime<Local>,
   ) -> color_eyre::Result<()> {
@@ -994,18 +1040,12 @@ impl TracerInner {
     let pid = guard.pid();
     let mut store = self.store.borrow_mut();
     let p = store.get_current_mut(pid).unwrap();
-    p.presyscall = !p.presyscall;
-    let result = match guard.syscall_info() {
-      Ok(r) => r.syscall_result().unwrap(),
-      Err(Errno::ESRCH) => {
-        info!("ptrace get_syscall_info failed: {pid}, ESRCH, child probably gone!");
-        return Ok(());
-      }
-      Err(e) => return Err(e.into()),
-    };
+    p.presyscall = true;
+    debug_assert!(!info.is_entry());
+    let result = info.syscall_result().unwrap();
     // If exec is successful, the register value might be clobbered.
     // TODO: would the value in ptrace_syscall_info be clobbered?
-    let exec_result = if p.is_exec_successful { 0 } else { result } as i64;
+    let exec_result = if p.is_exec_successful { 0 } else { result };
     match p.syscall {
       Syscall::Execve | Syscall::Execveat => {
         trace!("post execve(at) in exec");

--- a/crates/tracexec-backend-ptrace/src/ptrace/tracer/test.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace/tracer/test.rs
@@ -3,7 +3,16 @@ use std::{
   ffi::CString,
   os::unix::ffi::OsStrExt,
   path::PathBuf,
+  process::{
+    Command,
+    Stdio,
+  },
   sync::Arc,
+  time::{
+    Duration,
+    SystemTime,
+    UNIX_EPOCH,
+  },
 };
 
 use nix::sys::signal::Signal as NixSignal;
@@ -346,6 +355,71 @@ async fn tracer_reports_root_tracee_signaled(
   assert!(saw_tracee_exit, "TraceeExit event not found");
 }
 
+// Regression test: ensures that tracer do not panic on duplicated syscall exit stops
+//                  caused by restarted syscalls
+#[traced_test]
+#[rstest]
+#[file_serial]
+#[tokio::test]
+async fn tracer_handles_first_exit_stop_after_attach(
+  #[with(Default::default(), SeccompBpf::Off)] tracer: TracerFixture,
+) {
+  let (tracer, mut rx, token) = tracer;
+  let nonce = SystemTime::now()
+    .duration_since(UNIX_EPOCH)
+    .unwrap()
+    .as_nanos();
+  let ready_path = env::temp_dir().join(format!("tracexec-ptrace-restart-{nonce}"));
+  let ready_path_arg = ready_path.to_string_lossy().into_owned();
+  let mut tracee = Command::new("/proc/self/exe")
+    .args([
+      "--ignored",
+      "ptrace_attach_nanosleep_helper",
+      &ready_path_arg,
+    ])
+    .stdin(Stdio::null())
+    .stdout(Stdio::null())
+    .stderr(Stdio::null())
+    .spawn()
+    .unwrap();
+  drop(token);
+
+  let tracee_tid = tokio::time::timeout(Duration::from_secs(5), async {
+    loop {
+      if let Ok(contents) = std::fs::read_to_string(&ready_path) {
+        break contents.parse::<i32>().unwrap();
+      }
+      tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+  })
+  .await
+  .expect("helper did not enter nanosleep");
+  std::fs::remove_file(&ready_path).unwrap();
+
+  let tracer_thread = tracer.attach_for_test(nix::unistd::Pid::from_raw(tracee_tid));
+  tracer_thread.await.unwrap().unwrap();
+  assert!(tracee.wait().unwrap().success());
+
+  let mut events = vec![];
+  while let Some(event) = rx.recv().await {
+    events.push(event);
+  }
+
+  assert!(events.iter().any(|event| {
+    matches!(
+      event,
+      TracerMessage::Event(TracerEvent {
+        details: TracerEventDetails::TraceeExit {
+          signal: None,
+          exit_code: 0,
+          ..
+        },
+        ..
+      })
+    )
+  }));
+}
+
 #[traced_test]
 #[rstest]
 #[file_serial]
@@ -511,4 +585,35 @@ fn ptrace_execveat_non_main_thread_helper() {
 
   let _ = join.join();
   panic!("execveat from non-main thread did not replace process image");
+}
+
+#[test]
+#[ignore]
+fn ptrace_attach_nanosleep_helper() {
+  let ready_path = env::args().nth(3).unwrap();
+  let tracee_tid = nix::unistd::gettid();
+  assert_eq!(
+    unsafe {
+      nix::libc::prctl(
+        nix::libc::PR_SET_PTRACER,
+        nix::libc::PR_SET_PTRACER_ANY,
+        0,
+        0,
+        0,
+      )
+    },
+    0
+  );
+  let ready_thread = std::thread::spawn(move || {
+    std::thread::sleep(Duration::from_millis(20));
+    std::fs::write(ready_path, tracee_tid.as_raw().to_string()).unwrap();
+  });
+
+  let request = nix::libc::timespec {
+    tv_sec: 0,
+    tv_nsec: 500_000_000,
+  };
+  let result = unsafe { nix::libc::nanosleep(&request, std::ptr::null_mut()) };
+  assert_eq!(result, 0, "nanosleep should complete after ptrace restart");
+  ready_thread.join().unwrap();
 }


### PR DESCRIPTION
…alls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ptrace syscall tracking to reliably distinguish syscall entry and exit events.
  - Fixed tracing behavior for restarted syscalls that produce consecutive exit events.
  - Improved handling when attaching to an already-running process, including its first exit stop.
  - Gracefully handles processes that exit while syscall information is being collected.

- **Tests**
  - Added regression coverage for attaching to processes during sleep and verifying successful completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->