### PR TITLE
bpf: skip compat hooks when !IA32_EMULATION

### DIFF
--- a/crates/tracexec-backend-ebpf/src/bin/verifier_complexity.rs
+++ b/crates/tracexec-backend-ebpf/src/bin/verifier_complexity.rs
@@ -26,6 +26,8 @@ use libbpf_sys::{
   BPF_F_SLEEPABLE,
 };
 use serde::Serialize;
+#[cfg(target_arch = "x86_64")]
+use tracexec_backend_ebpf::probe::should_load_compat_syscall_hooks;
 use tracexec_backend_ebpf::{
   bpf::skel::{
     OpenTracexecSystemSkel,
@@ -203,13 +205,13 @@ fn load_cases() -> Vec<LoadCase> {
       LoadCase {
         name: "compat-execve-fentry",
         prepare: prepare_compat_execve_fentry,
-        skip: skip_fentry,
+        skip: skip_compat_fentry,
         skip_invalid_argument: true,
       },
       LoadCase {
         name: "compat-execveat-fentry",
         prepare: prepare_compat_execveat_fentry,
-        skip: skip_fentry,
+        skip: skip_compat_fentry,
         skip_invalid_argument: true,
       },
     ]);
@@ -225,6 +227,15 @@ fn never_skip() -> Option<&'static str> {
 fn skip_fentry() -> Option<&'static str> {
   (!kernel_have_ftrace_with_direct_calls(KCONFIG.as_ref(), None))
     .then_some("missing CONFIG_DYNAMIC_FTRACE_WITH_DIRECT_CALLS")
+}
+
+#[cfg(target_arch = "x86_64")]
+fn skip_compat_fentry() -> Option<&'static str> {
+  if !should_load_compat_syscall_hooks(KCONFIG.as_ref()) {
+    Some("missing CONFIG_IA32_EMULATION")
+  } else {
+    skip_fentry()
+  }
 }
 
 fn skip_syscall_wrapper_kprobe() -> Option<&'static str> {
@@ -451,6 +462,14 @@ fn prepare_production(open_skel: &mut OpenTracexecSystemSkel<'_>) -> Result<()> 
   rodata.tracexec_config.follow_fork = MaybeUninit::new(false);
   rodata.tracexec_config.tracee_pid = 0;
   rodata.tracexec_config.tracee_pidns_inum = std::fs::metadata("/proc/self/ns/pid")?.ino() as u32;
+
+  #[cfg(target_arch = "x86_64")]
+  if !should_load_compat_syscall_hooks(KCONFIG.as_ref()) {
+    open_skel.progs.compat_sys_execve.set_autoload(false);
+    open_skel.progs.compat_sys_execveat.set_autoload(false);
+    open_skel.progs.compat_sys_exit_execve.set_autoload(false);
+    open_skel.progs.compat_sys_exit_execveat.set_autoload(false);
+  }
 
   if !kernel_have_ftrace_with_direct_calls(KCONFIG.as_ref(), None) {
     open_skel.progs.sys_execve_fentry.set_autoload(false);

--- a/crates/tracexec-backend-ebpf/src/probe.rs
+++ b/crates/tracexec-backend-ebpf/src/probe.rs
@@ -15,6 +15,16 @@ pub fn kernel_supports_sleepable_no_prealloc_hash_maps() -> bool {
   tracexec_core::is_current_kernel_ge(MIN_SLEEPABLE_NO_PREALLOC_HASH_MAPS).unwrap_or_default()
 }
 
+/// Returns whether compat syscall hooks should be loaded.
+///
+/// When the kernel configuration cannot be read, assume that legacy 32-bit x86
+/// programs are supported and keep the corresponding eBPF programs enabled.
+pub fn should_load_compat_syscall_hooks(kconfig: Option<&HashMap<String, ConfigSetting>>) -> bool {
+  // procfs omits `# CONFIG_IA32_EMULATION is not set`, so the option is absent
+  // from a successfully read configuration when support is disabled.
+  kconfig.is_none_or(|configs| configs.contains_key("CONFIG_IA32_EMULATION"))
+}
+
 pub fn kernel_have_syscall_wrappers(
   #[allow(unused)] kconfig: Option<&HashMap<String, ConfigSetting>>,
 ) -> bool {
@@ -120,7 +130,26 @@ mod tests {
     kernel_have_ftrace_with_direct_calls,
     kernel_have_syscall_wrappers,
     kernel_rejects_syscall_wrapper_kprobes,
+    should_load_compat_syscall_hooks,
   };
+
+  #[test]
+  fn test_loads_compat_syscall_hooks_when_ia32_emulation_enabled() {
+    let mut configs = HashMap::new();
+    configs.insert("CONFIG_IA32_EMULATION".to_string(), ConfigSetting::Yes);
+
+    assert!(should_load_compat_syscall_hooks(Some(&configs)));
+  }
+
+  #[test]
+  fn test_skips_compat_syscall_hooks_when_ia32_emulation_disabled() {
+    assert!(!should_load_compat_syscall_hooks(Some(&HashMap::new())));
+  }
+
+  #[test]
+  fn test_loads_compat_syscall_hooks_when_ia32_emulation_unknown() {
+    assert!(should_load_compat_syscall_hooks(None));
+  }
 
   rusty_fork_test! {
     #[test]

--- a/crates/tracexec-backend-ebpf/src/tracer.rs
+++ b/crates/tracexec-backend-ebpf/src/tracer.rs
@@ -120,6 +120,8 @@ use tracing::{
 };
 
 use self::private::Sealed;
+#[cfg(target_arch = "x86_64")]
+use crate::probe::should_load_compat_syscall_hooks;
 use crate::{
   bpf::{
     BpfError,
@@ -771,6 +773,13 @@ impl EbpfTracer {
     let kconfig = procfs::kernel_config()
       .inspect_err(|e| warn!("Failed to get kernel config: {e}"))
       .ok();
+    #[cfg(target_arch = "x86_64")]
+    if !should_load_compat_syscall_hooks(kconfig.as_ref()) {
+      open_skel.progs.compat_sys_execve.set_autoload(false);
+      open_skel.progs.compat_sys_execveat.set_autoload(false);
+      open_skel.progs.compat_sys_exit_execve.set_autoload(false);
+      open_skel.progs.compat_sys_exit_execveat.set_autoload(false);
+    }
     if kernel_supports_sleepable_no_prealloc_hash_maps() {
       open_skel
         .maps

--- a/crates/tracexec-backend-ebpf/tests/exec_events.rs
+++ b/crates/tracexec-backend-ebpf/tests/exec_events.rs
@@ -33,6 +33,8 @@ use rstest::{
   rstest,
 };
 use serial_test::file_serial;
+#[cfg(target_arch = "x86_64")]
+use tracexec_backend_ebpf::probe::should_load_compat_syscall_hooks;
 use tracexec_backend_ebpf::{
   bpf::{
     interface::BpfEventFlags,
@@ -695,6 +697,9 @@ fn test_execveat_from_non_main_thread_emits_non_main_exec_pid(
 #[file_serial(bpf)]
 #[ignore = "root"]
 fn test_compat_exec_emits_exec_event(#[case] probe: CompatExecProbe) -> color_eyre::Result<()> {
+  if !should_load_compat_syscall_hooks(KCONFIG.as_ref()) {
+    return Ok(());
+  }
   let bin = PathBuf::from(env!("CARGO_BIN_EXE_compat-exec"));
   let test_name = format!("{}_{}", function_name!(), probe.test_suffix());
   with_optional_sleepable_skel(&test_name, probe.prepare(), |skel| {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility syscall hook handling on x86_64 systems.
  - Prevented unsupported compatibility hooks from loading when the kernel lacks required configuration.
  - Added clearer handling for environments where kernel configuration cannot be read.

- **Tests**
  - Added coverage for enabled, disabled, and unavailable compatibility configuration scenarios.
  - Updated compatibility execution-event tests to skip when the required hooks are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->