### PR TITLE
poc: job control

### DIFF
--- a/book/features/ptrace.md
+++ b/book/features/ptrace.md
@@ -24,6 +24,37 @@ we avoid incurring overhead on other syscalls the tracee makes.
 In case you want to learn more about this optimization, read the
 [well-written blog post from strace developer](https://pchaigno.github.io/strace/2019/10/02/introducing-strace-seccomp-bpf.html).
 
+## Subprocess Job Control
+
+The ptrace backend can control subprocess parallelism without cooperating with
+the build system. Pass `--job-control auto` to a ptrace frontend and allow the
+build system to create jobs without its own limit. For example:
+
+```console
+tracexec log --job-control auto -- make -j
+```
+
+Automatic job control has no fixed job-count or core-count limit. On kernels
+with Pressure Stall Information (PSI), it measures CPU contention and full
+memory stalls instead of treating fully utilized CPUs or a fixed percentage of
+reclaimable memory as unavailable. CPU utilization and available memory are
+used as fallbacks when PSI is unavailable.
+
+Additional subprocesses are paused at successful exec syscall-exit stops only
+while resources are constrained. A completed process tree is replaced
+immediately; when pressure drops, additional paused jobs are resumed gradually
+in FIFO order to avoid a thundering herd. Descendants inherit their parent's
+admission, so a job can run and wait for helper processes such as a compiler
+waiting for its assembler without deadlocking. The traced root command is not
+counted as a job, and one process tree is always allowed to run to guarantee
+forward progress.
+
+By default, job control uses blocking `waitpid` so ptrace events are handled as
+soon as they arrive. A lightweight timer thread interrupts the blocked tracer
+only for periodic resource reevaluation; it does not poll for ptrace events.
+The timer thread remains parked while no subprocesses are waiting. An
+explicitly configured positive `--polling-interval` still selects polling mode.
+
 ## Strengths
 
 - Works out of the box.

--- a/config.toml
+++ b/config.toml
@@ -10,6 +10,8 @@
 [ptrace]
 # Enable seccomp_bpf to optimize performance, values: Auto, On or Off
 # seccomp_bpf = "Auto"
+# Dynamically control subprocess parallelism, values: Auto
+# job_control = "Auto"
 
 #
 # Debugger config

--- a/crates/tracexec-backend-ptrace/src/ptrace.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace.rs
@@ -1,6 +1,7 @@
 mod engine;
 mod guards;
 mod inspect;
+mod job_control;
 mod syscall;
 mod tracer;
 mod waitpid;

--- a/crates/tracexec-backend-ptrace/src/ptrace/job_control.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace/job_control.rs
@@ -1,0 +1,995 @@
+use std::{
+  collections::{
+    HashMap,
+    HashSet,
+    VecDeque,
+  },
+  fs,
+  io,
+  sync::{
+    Arc,
+    OnceLock,
+    atomic::{
+      AtomicBool,
+      Ordering,
+    },
+  },
+  thread::Thread,
+  time::{
+    Duration,
+    Instant,
+  },
+};
+
+use nix::unistd::Pid;
+use tracing::{
+  debug,
+  info,
+  trace,
+  warn,
+};
+
+pub(super) const RESOURCE_SAMPLE_INTERVAL: Duration = Duration::from_millis(10);
+const CPU_STALL_THRESHOLD: f64 = 0.20;
+const MEMORY_FULL_STALL_THRESHOLD: f64 = 0.02;
+const FALLBACK_CPU_UTILIZATION_THRESHOLD: f64 = 0.98;
+const EMERGENCY_AVAILABLE_MEMORY_RATIO: f64 = 0.01;
+const FALLBACK_AVAILABLE_MEMORY_RATIO: f64 = 0.05;
+const MIN_AVAILABLE_MEMORY_BYTES: u64 = 256 * 1024 * 1024;
+
+#[derive(Default)]
+pub(super) struct JobControlWakeupState {
+  waiting_jobs: AtomicBool,
+  worker: OnceLock<Thread>,
+}
+
+impl JobControlWakeupState {
+  pub(super) fn register_worker(&self, worker: Thread) {
+    assert!(
+      self.worker.set(worker).is_ok(),
+      "job-control wakeup worker was registered twice"
+    );
+  }
+
+  pub(super) fn has_waiting_jobs(&self) -> bool {
+    self.waiting_jobs.load(Ordering::Acquire)
+  }
+
+  fn set_waiting_jobs(&self, waiting: bool) {
+    let was_waiting = self.waiting_jobs.swap(waiting, Ordering::AcqRel);
+    if waiting
+      && !was_waiting
+      && let Some(worker) = self.worker.get()
+    {
+      worker.unpark();
+    }
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(super) struct SystemLoad {
+  cpu_stall: Option<f64>,
+  cpu_utilization: Option<f64>,
+  memory_full_stall: Option<f64>,
+  available_memory: u64,
+  total_memory: u64,
+}
+
+impl SystemLoad {
+  fn pressure(self) -> Option<Pressure> {
+    match self.cpu_stall {
+      Some(stalled) if stalled >= CPU_STALL_THRESHOLD => {
+        return Some(Pressure::CpuStall { stalled });
+      }
+      Some(_) => {}
+      None => {
+        if let Some(utilization) = self.cpu_utilization
+          && utilization >= FALLBACK_CPU_UTILIZATION_THRESHOLD
+        {
+          return Some(Pressure::CpuUtilizationFallback { utilization });
+        }
+      }
+    }
+
+    if let Some(stalled) = self.memory_full_stall
+      && stalled >= MEMORY_FULL_STALL_THRESHOLD
+    {
+      return Some(Pressure::MemoryStall { stalled });
+    }
+
+    if self.total_memory > 0 {
+      let ratio = if self.memory_full_stall.is_some() {
+        EMERGENCY_AVAILABLE_MEMORY_RATIO
+      } else {
+        FALLBACK_AVAILABLE_MEMORY_RATIO
+      };
+      let proportional_reserve = (self.total_memory as f64 * ratio) as u64;
+      let absolute_reserve = MIN_AVAILABLE_MEMORY_BYTES.min(self.total_memory / 10);
+      let reserve = proportional_reserve.max(absolute_reserve);
+      if self.available_memory <= reserve {
+        return Some(Pressure::MemoryAvailability {
+          reserve,
+          available: self.available_memory,
+          total: self.total_memory,
+        });
+      }
+    }
+
+    None
+  }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum Pressure {
+  CpuStall {
+    stalled: f64,
+  },
+  CpuUtilizationFallback {
+    utilization: f64,
+  },
+  MemoryStall {
+    stalled: f64,
+  },
+  MemoryAvailability {
+    reserve: u64,
+    available: u64,
+    total: u64,
+  },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PsiTotals {
+  cpu_some: u64,
+  memory_full: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PsiSample {
+  at: Instant,
+  totals: PsiTotals,
+}
+
+fn stall_ratio(
+  previous: PsiSample,
+  current: PsiSample,
+  total: u64,
+  previous_total: u64,
+) -> Option<f64> {
+  let elapsed = current
+    .at
+    .saturating_duration_since(previous.at)
+    .as_secs_f64();
+  let stalled = total.checked_sub(previous_total)? as f64 / 1_000_000.0;
+  (elapsed > 0.0).then(|| (stalled / elapsed).clamp(0.0, 1.0))
+}
+
+fn parse_psi_total(psi: &str, category: &str) -> io::Result<u64> {
+  let line = psi
+    .lines()
+    .find(|line| line.split_ascii_whitespace().next() == Some(category))
+    .ok_or_else(|| invalid_data(format!("{category} PSI line is missing")))?;
+  let total = line
+    .split_ascii_whitespace()
+    .find_map(|field| field.strip_prefix("total="))
+    .ok_or_else(|| invalid_data(format!("total is missing from {category} PSI line")))?;
+  total
+    .parse()
+    .map_err(|error| invalid_data(format!("invalid {category} PSI total `{total}`: {error}")))
+}
+
+fn read_psi_totals() -> io::Result<PsiTotals> {
+  Ok(PsiTotals {
+    cpu_some: parse_psi_total(&fs::read_to_string("/proc/pressure/cpu")?, "some")?,
+    memory_full: parse_psi_total(&fs::read_to_string("/proc/pressure/memory")?, "full")?,
+  })
+}
+
+pub(super) trait LoadProbe {
+  fn sample(&mut self) -> io::Result<SystemLoad>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CpuTimes {
+  total: u64,
+  idle: u64,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct ProcLoadProbe {
+  previous_cpu_times: Option<CpuTimes>,
+  previous_psi: Option<PsiSample>,
+  psi_supported: Option<bool>,
+}
+
+impl LoadProbe for ProcLoadProbe {
+  fn sample(&mut self) -> io::Result<SystemLoad> {
+    let current_psi = if self.psi_supported == Some(false) {
+      None
+    } else {
+      match read_psi_totals() {
+        Ok(totals) => {
+          self.psi_supported = Some(true);
+          Some(PsiSample {
+            at: Instant::now(),
+            totals,
+          })
+        }
+        Err(error) => {
+          warn!(%error, "Linux PSI is unavailable; job control is using CPU-utilization and memory-availability fallbacks");
+          self.psi_supported = Some(false);
+          self.previous_psi = None;
+          None
+        }
+      }
+    };
+    let (cpu_stall, memory_full_stall) = self
+      .previous_psi
+      .zip(current_psi)
+      .map(|(previous, current)| {
+        (
+          stall_ratio(
+            previous,
+            current,
+            current.totals.cpu_some,
+            previous.totals.cpu_some,
+          ),
+          stall_ratio(
+            previous,
+            current,
+            current.totals.memory_full,
+            previous.totals.memory_full,
+          ),
+        )
+      })
+      .unwrap_or_default();
+    if let Some(current_psi) = current_psi {
+      self.previous_psi = Some(current_psi);
+    }
+
+    let cpu_utilization = if cpu_stall.is_none() {
+      let current_cpu_times = parse_cpu_times(&fs::read_to_string("/proc/stat")?)?;
+      let utilization = self.previous_cpu_times.and_then(|previous| {
+        let total = current_cpu_times.total.checked_sub(previous.total)?;
+        let idle = current_cpu_times.idle.checked_sub(previous.idle)?;
+        (total > 0).then(|| 1.0 - idle.min(total) as f64 / total as f64)
+      });
+      self.previous_cpu_times = Some(current_cpu_times);
+      utilization
+    } else {
+      None
+    };
+
+    let (available_memory, total_memory) =
+      parse_memory_info(&fs::read_to_string("/proc/meminfo")?)?;
+
+    Ok(SystemLoad {
+      cpu_stall,
+      cpu_utilization,
+      memory_full_stall,
+      available_memory,
+      total_memory,
+    })
+  }
+}
+
+fn invalid_data(message: impl Into<String>) -> io::Error {
+  io::Error::new(io::ErrorKind::InvalidData, message.into())
+}
+
+fn parse_cpu_times(stat: &str) -> io::Result<CpuTimes> {
+  let cpu_line = stat
+    .lines()
+    .find(|line| line.starts_with("cpu "))
+    .ok_or_else(|| invalid_data("aggregate CPU line is missing from /proc/stat"))?;
+  let values = cpu_line
+    .split_ascii_whitespace()
+    .skip(1)
+    .take(8)
+    .map(|value| {
+      value
+        .parse::<u64>()
+        .map_err(|error| invalid_data(format!("invalid CPU counter `{value}`: {error}")))
+    })
+    .collect::<io::Result<Vec<_>>>()?;
+  if values.len() < 4 {
+    return Err(invalid_data("too few aggregate CPU counters in /proc/stat"));
+  }
+
+  let total = values
+    .iter()
+    .try_fold(0_u64, |total, value| total.checked_add(*value))
+    .ok_or_else(|| invalid_data("aggregate CPU counters overflowed"))?;
+  let idle = values[3]
+    .checked_add(values.get(4).copied().unwrap_or_default())
+    .ok_or_else(|| invalid_data("aggregate idle CPU counters overflowed"))?;
+  Ok(CpuTimes { total, idle })
+}
+
+fn parse_memory_info(meminfo: &str) -> io::Result<(u64, u64)> {
+  fn value(meminfo: &str, key: &str) -> io::Result<u64> {
+    let line = meminfo
+      .lines()
+      .find(|line| line.starts_with(key))
+      .ok_or_else(|| invalid_data(format!("{key} is missing from /proc/meminfo")))?;
+    let mut fields = line.split_ascii_whitespace();
+    let _key = fields.next();
+    let kibibytes = fields
+      .next()
+      .ok_or_else(|| invalid_data(format!("{key} has no value in /proc/meminfo")))?
+      .parse::<u64>()
+      .map_err(|error| invalid_data(format!("invalid {key} value: {error}")))?;
+    kibibytes
+      .checked_mul(1024)
+      .ok_or_else(|| invalid_data(format!("{key} value overflowed")))
+  }
+
+  Ok((
+    value(meminfo, "MemAvailable:")?,
+    value(meminfo, "MemTotal:")?,
+  ))
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Admission {
+  Run,
+  Wait,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct JobId(u64);
+
+pub(super) struct AutoJobController<P = ProcLoadProbe> {
+  // Each admitted process tree is one job. Descendants inherit its admission so
+  // a parent can wait for a child without the child being independently queued.
+  jobs: HashMap<JobId, usize>,
+  memberships: HashMap<Pid, JobId>,
+  next_job_id: u64,
+  waiting: HashSet<Pid>,
+  wait_queue: VecDeque<Pid>,
+  completion_permits: usize,
+  probe: P,
+  last_sample: Option<SystemLoad>,
+  last_sample_at: Option<Instant>,
+  sample_interval: Duration,
+  sample_generation: u64,
+  last_recovery_generation: u64,
+  wakeup_state: Arc<JobControlWakeupState>,
+  probe_failed: bool,
+}
+
+impl AutoJobController {
+  pub(super) fn new(wakeup_state: Arc<JobControlWakeupState>) -> Self {
+    let mut controller = Self::with_probe(
+      ProcLoadProbe::default(),
+      RESOURCE_SAMPLE_INTERVAL,
+      wakeup_state,
+    );
+    let _ = controller.refresh_load(true);
+    info!(
+      cpu_stall_threshold = CPU_STALL_THRESHOLD,
+      memory_full_stall_threshold = MEMORY_FULL_STALL_THRESHOLD,
+      fallback_cpu_utilization_threshold = FALLBACK_CPU_UTILIZATION_THRESHOLD,
+      emergency_available_memory_ratio = EMERGENCY_AVAILABLE_MEMORY_RATIO,
+      fallback_available_memory_ratio = FALLBACK_AVAILABLE_MEMORY_RATIO,
+      sample_interval_ms = RESOURCE_SAMPLE_INTERVAL.as_millis(),
+      "resource-based automatic subprocess job control enabled"
+    );
+    controller
+  }
+}
+
+impl<P: LoadProbe> AutoJobController<P> {
+  fn with_probe(
+    probe: P,
+    sample_interval: Duration,
+    wakeup_state: Arc<JobControlWakeupState>,
+  ) -> Self {
+    Self {
+      jobs: HashMap::new(),
+      memberships: HashMap::new(),
+      next_job_id: 1,
+      waiting: HashSet::new(),
+      wait_queue: VecDeque::new(),
+      completion_permits: 0,
+      probe,
+      last_sample: None,
+      last_sample_at: None,
+      sample_interval,
+      sample_generation: 0,
+      last_recovery_generation: 0,
+      wakeup_state,
+      probe_failed: false,
+    }
+  }
+
+  fn refresh_load(&mut self, force: bool) -> Option<SystemLoad> {
+    if !force
+      && self
+        .last_sample_at
+        .is_some_and(|sampled| sampled.elapsed() < self.sample_interval)
+    {
+      return self.last_sample;
+    }
+
+    self.last_sample_at = Some(Instant::now());
+    self.sample_generation = self.sample_generation.wrapping_add(1);
+    match self.probe.sample() {
+      Ok(load) => {
+        if self.probe_failed {
+          info!("system resource sampling recovered for subprocess job control");
+        }
+        self.probe_failed = false;
+        self.last_sample = Some(load);
+        trace!(
+          cpu_stall = load.cpu_stall,
+          cpu_utilization = load.cpu_utilization,
+          memory_full_stall = load.memory_full_stall,
+          available_memory = load.available_memory,
+          total_memory = load.total_memory,
+          "sampled system resources for subprocess job control"
+        );
+      }
+      Err(error) => {
+        if !self.probe_failed {
+          warn!(%error, "failed to sample system resources; job control will admit jobs without pressure throttling");
+        }
+        self.probe_failed = true;
+        self.last_sample = None;
+      }
+    }
+    self.last_sample
+  }
+
+  fn start_job(&mut self, pid: Pid) -> JobId {
+    let job_id = JobId(self.next_job_id);
+    self.next_job_id = self
+      .next_job_id
+      .checked_add(1)
+      .expect("job-control identifier overflowed");
+    assert!(self.jobs.insert(job_id, 1).is_none());
+    assert!(self.memberships.insert(pid, job_id).is_none());
+    job_id
+  }
+
+  pub(super) fn admit(&mut self, pid: Pid) -> Admission {
+    if let Some(job_id) = self.memberships.get(&pid).copied() {
+      trace!(
+        %pid,
+        job_id = job_id.0,
+        "job control observed an exec in an admitted process tree"
+      );
+      return Admission::Run;
+    }
+    if self.waiting.contains(&pid) {
+      return Admission::Wait;
+    }
+
+    let pressure = if self.jobs.is_empty() {
+      // Always allow one controlled subprocess so external load cannot deadlock
+      // the tracee indefinitely.
+      None
+    } else {
+      // Keep the feedback window short enough that `make -j` cannot send a
+      // large burst through exec before the controller observes its load.
+      self.refresh_load(false).and_then(SystemLoad::pressure)
+    };
+
+    if let Some(pressure) = pressure {
+      self.waiting.insert(pid);
+      self.wait_queue.push_back(pid);
+      self.update_waiting_wakeup();
+      debug!(
+        %pid,
+        ?pressure,
+        running_jobs = self.jobs.len(),
+        waiting_jobs = self.waiting.len(),
+        "job control paused subprocess at exec syscall exit"
+      );
+      Admission::Wait
+    } else {
+      let job_id = self.start_job(pid);
+      trace!(
+        %pid,
+        job_id = job_id.0,
+        running_jobs = self.jobs.len(),
+        "job control admitted subprocess"
+      );
+      Admission::Run
+    }
+  }
+
+  pub(super) fn process_spawned(&mut self, parent: Pid, child: Pid) {
+    let Some(job_id) = self.memberships.get(&parent).copied() else {
+      return;
+    };
+    if let Some(existing_job_id) = self.memberships.get(&child).copied() {
+      trace!(
+        %parent,
+        %child,
+        job_id = existing_job_id.0,
+        "job control observed an already-accounted process child"
+      );
+      return;
+    }
+
+    self.memberships.insert(child, job_id);
+    let members = self
+      .jobs
+      .get_mut(&job_id)
+      .expect("job-control membership referenced a missing job");
+    *members = members
+      .checked_add(1)
+      .expect("job-control process count overflowed");
+    trace!(
+      %parent,
+      %child,
+      job_id = job_id.0,
+      job_members = *members,
+      "job control added child to its parent's process tree"
+    );
+  }
+
+  pub(super) fn process_execed(&mut self, former_tid: Pid, pid: Pid) {
+    if former_tid == pid {
+      return;
+    }
+
+    let Some(job_id) = self.memberships.remove(&former_tid) else {
+      return;
+    };
+    match self.memberships.get(&pid).copied() {
+      Some(existing_job_id) => {
+        debug_assert_eq!(existing_job_id, job_id);
+        let members = self
+          .jobs
+          .get_mut(&job_id)
+          .expect("job-control membership referenced a missing job");
+        *members = members
+          .checked_sub(1)
+          .expect("job-control process count underflowed after thread exec");
+        trace!(
+          %former_tid,
+          %pid,
+          job_id = job_id.0,
+          job_members = *members,
+          "job control merged a thread into its process leader after exec"
+        );
+      }
+      None => {
+        self.memberships.insert(pid, job_id);
+        trace!(
+          %former_tid,
+          %pid,
+          job_id = job_id.0,
+          "job control transferred membership after a thread exec"
+        );
+      }
+    }
+  }
+
+  pub(super) fn process_exited(&mut self, pid: Pid) -> bool {
+    if self.waiting.remove(&pid) {
+      self.wait_queue.retain(|waiting_pid| *waiting_pid != pid);
+      self.update_waiting_wakeup();
+      debug!(%pid, "subprocess exited while waiting for job-control admission");
+      true
+    } else if let Some(job_id) = self.memberships.remove(&pid) {
+      let members = self
+        .jobs
+        .get_mut(&job_id)
+        .expect("job-control membership referenced a missing job");
+      *members = members
+        .checked_sub(1)
+        .expect("job-control process count underflowed on exit");
+      if *members == 0 {
+        self.jobs.remove(&job_id);
+        self.completion_permits = self.completion_permits.saturating_add(1);
+        debug!(
+          %pid,
+          job_id = job_id.0,
+          running_jobs = self.jobs.len(),
+          waiting_jobs = self.waiting.len(),
+          "job-control process tree completed"
+        );
+      } else {
+        trace!(
+          %pid,
+          job_id = job_id.0,
+          job_members = *members,
+          "job-control process exited while descendants remain"
+        );
+      }
+      false
+    } else {
+      false
+    }
+  }
+
+  pub(super) fn jobs_ready_to_run(&mut self) -> Vec<Pid> {
+    if self.wait_queue.is_empty() {
+      self.completion_permits = 0;
+      return Vec::new();
+    }
+
+    let pressure = self.refresh_load(false).and_then(SystemLoad::pressure);
+    let mut ready = Vec::new();
+    while self.completion_permits > 0 {
+      let Some(pid) = self.start_next_waiting() else {
+        break;
+      };
+      self.completion_permits -= 1;
+      ready.push(pid);
+    }
+    self.completion_permits = 0;
+
+    // A single pressure-free sample grants one additional job. Resuming the
+    // whole FIFO from one sample causes a thundering herd and immediately
+    // drives the system back into contention.
+    if self.last_recovery_generation != self.sample_generation {
+      self.last_recovery_generation = self.sample_generation;
+      if (pressure.is_none() || self.jobs.is_empty())
+        && let Some(pid) = self.start_next_waiting()
+      {
+        ready.push(pid);
+      }
+    }
+
+    for pid in &ready {
+      debug!(
+        %pid,
+        running_jobs = self.jobs.len(),
+        waiting_jobs = self.waiting.len(),
+        "job control resumed subprocess"
+      );
+    }
+    ready
+  }
+
+  fn start_next_waiting(&mut self) -> Option<Pid> {
+    while let Some(pid) = self.wait_queue.pop_front() {
+      if self.waiting.remove(&pid) {
+        self.start_job(pid);
+        self.update_waiting_wakeup();
+        return Some(pid);
+      }
+    }
+    self.update_waiting_wakeup();
+    None
+  }
+
+  fn update_waiting_wakeup(&self) {
+    self.wakeup_state.set_waiting_jobs(!self.waiting.is_empty());
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::{
+    cell::RefCell,
+    rc::Rc,
+    sync::mpsc,
+    thread,
+  };
+
+  use tracing_test::traced_test;
+
+  use super::*;
+
+  #[derive(Debug, Clone, Copy)]
+  enum ProbeValue {
+    Load(SystemLoad),
+    Error(io::ErrorKind),
+  }
+
+  #[derive(Clone)]
+  struct FakeProbe(Rc<RefCell<ProbeValue>>);
+
+  impl LoadProbe for FakeProbe {
+    fn sample(&mut self) -> io::Result<SystemLoad> {
+      match *self.0.borrow() {
+        ProbeValue::Load(load) => Ok(load),
+        ProbeValue::Error(kind) => Err(io::Error::from(kind)),
+      }
+    }
+  }
+
+  #[test]
+  fn queued_work_unparks_resource_worker() {
+    let wakeup_state = Arc::new(JobControlWakeupState::default());
+    let (woke_tx, woke_rx) = mpsc::sync_channel(1);
+    let worker = thread::spawn(move || {
+      thread::park();
+      woke_tx.send(()).unwrap();
+    });
+    wakeup_state.register_worker(worker.thread().clone());
+
+    wakeup_state.set_waiting_jobs(true);
+    let woke = woke_rx.recv_timeout(Duration::from_secs(1));
+    // Avoid leaving a failed test's helper blocked forever.
+    worker.thread().unpark();
+    worker.join().unwrap();
+
+    assert!(woke.is_ok(), "resource worker was not notified");
+  }
+
+  fn low_load() -> SystemLoad {
+    SystemLoad {
+      cpu_stall: Some(0.0),
+      cpu_utilization: None,
+      memory_full_stall: Some(0.0),
+      available_memory: 90,
+      total_memory: 100,
+    }
+  }
+
+  fn cpu_pressure() -> SystemLoad {
+    SystemLoad {
+      cpu_stall: Some(0.99),
+      ..low_load()
+    }
+  }
+
+  fn controller(load: SystemLoad) -> (AutoJobController<FakeProbe>, Rc<RefCell<ProbeValue>>) {
+    let value = Rc::new(RefCell::new(ProbeValue::Load(load)));
+    (
+      AutoJobController::with_probe(
+        FakeProbe(value.clone()),
+        Duration::ZERO,
+        Arc::new(JobControlWakeupState::default()),
+      ),
+      value,
+    )
+  }
+
+  #[test]
+  fn parses_proc_resource_inputs() {
+    assert_eq!(
+      parse_cpu_times("cpu  10 2 3 20 5 1 2 1 7 4\ncpu0 1 1 1 1").unwrap(),
+      CpuTimes {
+        total: 44,
+        idle: 25,
+      }
+    );
+    assert_eq!(
+      parse_memory_info("MemTotal: 1000 kB\nMemAvailable: 125 kB\n").unwrap(),
+      (125 * 1024, 1000 * 1024)
+    );
+    assert_eq!(
+      parse_psi_total(
+        "some avg10=1.50 avg60=0.50 avg300=0.10 total=12345\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=67\n",
+        "some"
+      )
+      .unwrap(),
+      12345
+    );
+    assert_eq!(
+      parse_psi_total(
+        "some avg10=1.50 avg60=0.50 avg300=0.10 total=12345\nfull avg10=0.00 avg60=0.00 avg300=0.00 total=67\n",
+        "full"
+      )
+      .unwrap(),
+      67
+    );
+  }
+
+  #[test]
+  fn proc_probe_samples_host_resources() {
+    let load = ProcLoadProbe::default().sample().unwrap();
+    assert!(load.total_memory > 0);
+    assert!(load.available_memory <= load.total_memory);
+  }
+
+  #[test]
+  fn calculates_psi_stall_ratio_over_sample_window() {
+    let at = Instant::now();
+    let previous = PsiSample {
+      at,
+      totals: PsiTotals {
+        cpu_some: 10_000,
+        memory_full: 0,
+      },
+    };
+    let current = PsiSample {
+      at: at + Duration::from_millis(100),
+      totals: PsiTotals {
+        cpu_some: 30_000,
+        memory_full: 0,
+      },
+    };
+    let ratio = stall_ratio(
+      previous,
+      current,
+      current.totals.cpu_some,
+      previous.totals.cpu_some,
+    )
+    .unwrap();
+    assert!((ratio - 0.2).abs() < f64::EPSILON);
+  }
+
+  #[test]
+  fn does_not_limit_job_count_when_resources_are_available() {
+    let (mut controller, _) = controller(low_load());
+    for raw_pid in 1..=128 {
+      assert_eq!(controller.admit(Pid::from_raw(raw_pid)), Admission::Run);
+    }
+    assert_eq!(controller.jobs.len(), 128);
+    assert!(controller.waiting.is_empty());
+  }
+
+  #[test]
+  fn load_drop_releases_pressure_waiters() {
+    let (mut controller, probe) = controller(cpu_pressure());
+    assert_eq!(controller.admit(Pid::from_raw(1)), Admission::Run);
+    assert_eq!(controller.admit(Pid::from_raw(2)), Admission::Wait);
+    assert!(controller.jobs_ready_to_run().is_empty());
+
+    *probe.borrow_mut() = ProbeValue::Load(low_load());
+    assert_eq!(controller.jobs_ready_to_run(), [Pid::from_raw(2)]);
+  }
+
+  #[test]
+  fn completed_job_is_replaced_during_sustained_pressure() {
+    let (mut controller, _) = controller(cpu_pressure());
+    assert_eq!(controller.admit(Pid::from_raw(1)), Admission::Run);
+    assert_eq!(controller.admit(Pid::from_raw(2)), Admission::Wait);
+
+    controller.process_exited(Pid::from_raw(1));
+    assert_eq!(controller.jobs_ready_to_run(), [Pid::from_raw(2)]);
+  }
+
+  #[test]
+  fn memory_pressure_queues_new_jobs() {
+    let low_memory = SystemLoad {
+      available_memory: 10,
+      total_memory: 100,
+      ..low_load()
+    };
+    let (mut controller, _) = controller(low_memory);
+    assert_eq!(controller.admit(Pid::from_raw(1)), Admission::Run);
+    assert_eq!(controller.admit(Pid::from_raw(2)), Admission::Wait);
+  }
+
+  #[test]
+  fn reclaimable_memory_below_old_ten_percent_limit_remains_usable() {
+    let gibibyte = 1024_u64.pow(3);
+    let available_memory = 2 * gibibyte;
+    let total_memory = 50 * gibibyte;
+    let load = SystemLoad {
+      available_memory,
+      total_memory,
+      ..low_load()
+    };
+    assert_eq!(load.pressure(), None);
+  }
+
+  #[test]
+  fn memory_full_stall_queues_new_jobs() {
+    let load = SystemLoad {
+      memory_full_stall: Some(0.03),
+      ..low_load()
+    };
+    let (mut controller, _) = controller(load);
+    assert_eq!(controller.admit(Pid::from_raw(1)), Admission::Run);
+    assert_eq!(controller.admit(Pid::from_raw(2)), Admission::Wait);
+  }
+
+  #[test]
+  fn cpu_utilization_is_only_used_when_psi_is_unavailable() {
+    let load = SystemLoad {
+      cpu_stall: None,
+      cpu_utilization: Some(0.99),
+      memory_full_stall: None,
+      ..low_load()
+    };
+    assert!(matches!(
+      load.pressure(),
+      Some(Pressure::CpuUtilizationFallback { .. })
+    ));
+  }
+
+  #[test]
+  fn full_cpu_utilization_without_psi_stalls_is_not_pressure() {
+    let load = SystemLoad {
+      cpu_stall: Some(0.0),
+      cpu_utilization: Some(1.0),
+      ..low_load()
+    };
+    assert_eq!(load.pressure(), None);
+  }
+
+  #[test]
+  fn resource_recovery_wakes_one_extra_job_per_sample() {
+    let (mut controller, probe) = controller(cpu_pressure());
+    assert_eq!(controller.admit(Pid::from_raw(1)), Admission::Run);
+    assert_eq!(controller.admit(Pid::from_raw(2)), Admission::Wait);
+    assert_eq!(controller.admit(Pid::from_raw(3)), Admission::Wait);
+    assert_eq!(controller.admit(Pid::from_raw(4)), Admission::Wait);
+    assert!(controller.wakeup_state.has_waiting_jobs());
+
+    *probe.borrow_mut() = ProbeValue::Load(low_load());
+    assert_eq!(controller.jobs_ready_to_run(), [Pid::from_raw(2)]);
+    assert_eq!(controller.jobs_ready_to_run(), [Pid::from_raw(3)]);
+    assert_eq!(controller.jobs_ready_to_run(), [Pid::from_raw(4)]);
+    assert!(!controller.wakeup_state.has_waiting_jobs());
+  }
+
+  #[test]
+  fn repeated_exec_does_not_create_another_job() {
+    let (mut controller, _) = controller(low_load());
+    let pid = Pid::from_raw(1);
+    assert_eq!(controller.admit(pid), Admission::Run);
+    assert_eq!(controller.admit(pid), Admission::Run);
+    assert_eq!(controller.jobs.len(), 1);
+  }
+
+  #[test]
+  fn descendant_exec_inherits_admission_without_deadlocking_parent() {
+    let (mut controller, _) = controller(cpu_pressure());
+    let gcc = Pid::from_raw(1);
+    let assembler = Pid::from_raw(2);
+    let unrelated_job = Pid::from_raw(3);
+
+    assert_eq!(controller.admit(gcc), Admission::Run);
+    controller.process_spawned(gcc, assembler);
+    assert_eq!(controller.admit(assembler), Admission::Run);
+    assert_eq!(controller.jobs.len(), 1);
+    assert_eq!(controller.admit(unrelated_job), Admission::Wait);
+
+    assert!(!controller.process_exited(gcc));
+    assert!(controller.jobs_ready_to_run().is_empty());
+    assert!(!controller.process_exited(assembler));
+    assert_eq!(controller.jobs_ready_to_run(), [unrelated_job]);
+  }
+
+  #[test]
+  fn exec_from_non_main_thread_keeps_one_process_tree_member() {
+    let (mut controller, _) = controller(low_load());
+    let leader = Pid::from_raw(1);
+    let thread = Pid::from_raw(2);
+
+    assert_eq!(controller.admit(leader), Admission::Run);
+    controller.process_spawned(leader, thread);
+    controller.process_execed(thread, leader);
+
+    assert_eq!(controller.jobs.len(), 1);
+    assert_eq!(controller.memberships.len(), 1);
+    assert!(!controller.process_exited(leader));
+    assert!(controller.jobs.is_empty());
+  }
+
+  #[test]
+  fn queued_process_exit_removes_it_from_fifo() {
+    let (mut controller, _) = controller(cpu_pressure());
+    controller.admit(Pid::from_raw(1));
+    controller.admit(Pid::from_raw(2));
+    assert!(controller.wakeup_state.has_waiting_jobs());
+    assert!(controller.process_exited(Pid::from_raw(2)));
+    assert!(controller.jobs_ready_to_run().is_empty());
+    assert!(controller.waiting.is_empty());
+    assert!(!controller.wakeup_state.has_waiting_jobs());
+  }
+
+  #[test]
+  fn probe_failure_fails_open_without_a_fixed_job_limit() {
+    let (mut controller, probe) = controller(low_load());
+    *probe.borrow_mut() = ProbeValue::Error(io::ErrorKind::PermissionDenied);
+    assert_eq!(controller.admit(Pid::from_raw(1)), Admission::Run);
+    assert_eq!(controller.admit(Pid::from_raw(2)), Admission::Run);
+    assert_eq!(controller.admit(Pid::from_raw(3)), Admission::Run);
+  }
+
+  #[traced_test]
+  #[test]
+  fn logs_pause_and_resume_decisions() {
+    let (mut controller, _) = controller(cpu_pressure());
+    controller.admit(Pid::from_raw(1));
+    controller.admit(Pid::from_raw(2));
+    controller.process_exited(Pid::from_raw(1));
+    controller.jobs_ready_to_run();
+
+    assert!(logs_contain(
+      "job control paused subprocess at exec syscall exit"
+    ));
+    assert!(logs_contain("job control resumed subprocess"));
+  }
+}

--- a/crates/tracexec-backend-ptrace/src/ptrace/tracer.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace/tracer.rs
@@ -4,6 +4,7 @@ use std::{
     Arc,
     RwLock,
     atomic::{
+      AtomicBool,
       AtomicU32,
       Ordering,
     },
@@ -48,7 +49,10 @@ use tracexec_core::{
   },
   cli::{
     args::ModifierArgs,
-    options::SeccompBpf,
+    options::{
+      JobControl,
+      SeccompBpf,
+    },
   },
   event::{
     TracerEventDetailsKind,
@@ -65,11 +69,21 @@ use tracexec_core::{
     TracerMode,
   },
 };
-use tracing::trace;
+use tracing::{
+  debug,
+  trace,
+  warn,
+};
 
-use crate::ptrace::tracer::{
-  inner::TracerInner,
-  private::Sealed,
+use crate::ptrace::{
+  job_control::{
+    JobControlWakeupState,
+    RESOURCE_SAMPLE_INTERVAL,
+  },
+  tracer::{
+    inner::TracerInner,
+    private::Sealed,
+  },
 };
 
 mod inner;
@@ -85,6 +99,7 @@ pub struct Tracer {
   filter: BitFlags<TracerEventDetailsKind>,
   baseline: Arc<BaselineInfo>,
   seccomp_bpf: SeccompBpf,
+  job_control: Option<JobControl>,
   msg_tx: UnboundedSender<TracerMessage>,
   user: Option<User>,
   req_tx: UnboundedSender<PendingRequest>,
@@ -147,11 +162,13 @@ impl BuildPtraceTracer for TracerBuilder {
       TracerMode::Tui(tty) => tty.is_some(),
       TracerMode::Log { .. } => true,
     };
+    let job_control_enabled = self.job_control.is_some();
     let (req_tx, req_rx) = unbounded_channel();
     Ok((
       Tracer {
         with_tty,
         seccomp_bpf,
+        job_control: self.job_control,
         msg_tx,
         user: self.user,
         printer,
@@ -172,7 +189,9 @@ impl BuildPtraceTracer for TracerBuilder {
         baseline,
         req_tx: req_tx.clone(),
         polling_interval: {
-          if self.ptrace_blocking == Some(true) {
+          if self.ptrace_blocking == Some(true)
+            || (job_control_enabled && self.ptrace_blocking.is_none())
+          {
             None
           } else {
             let default = if seccomp_bpf == SeccompBpf::On {
@@ -209,6 +228,72 @@ pub enum PendingRequest {
 
 extern "C" fn empty_sighandler(_arg: c_int) {}
 
+fn notify_tracer_thread(tid: pthread_t) -> Result<(), Errno> {
+  let result = unsafe { pthread_kill(tid, nix::sys::signal::SIGUSR1 as c_int) };
+  if result == 0 {
+    Ok(())
+  } else {
+    Err(Errno::from_raw(result))
+  }
+}
+
+struct JobControlWakeup {
+  stop: Arc<AtomicBool>,
+  thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl JobControlWakeup {
+  fn spawn(
+    tracer_tid: pthread_t,
+    wakeup_state: Arc<JobControlWakeupState>,
+    blocking_waitpid: Arc<AtomicBool>,
+  ) -> std::io::Result<Self> {
+    let stop = Arc::new(AtomicBool::new(false));
+    let thread_stop = stop.clone();
+    let thread_wakeup_state = wakeup_state.clone();
+    let thread = std::thread::Builder::new()
+      .name("jc-wakeup".to_string())
+      .spawn(move || {
+        loop {
+          while !thread_wakeup_state.has_waiting_jobs() {
+            std::thread::park();
+            if thread_stop.load(Ordering::Acquire) {
+              return;
+            }
+          }
+          std::thread::park_timeout(RESOURCE_SAMPLE_INTERVAL);
+          if thread_stop.load(Ordering::Acquire) {
+            break;
+          }
+          if !thread_wakeup_state.has_waiting_jobs() || !blocking_waitpid.load(Ordering::Acquire) {
+            continue;
+          }
+          if let Err(error) = notify_tracer_thread(tracer_tid) {
+            debug!(%error, "job-control resource wakeup thread is stopping");
+            break;
+          }
+        }
+      })?;
+    wakeup_state.register_worker(thread.thread().clone());
+    Ok(Self {
+      stop,
+      thread: Some(thread),
+    })
+  }
+}
+
+impl Drop for JobControlWakeup {
+  fn drop(&mut self) {
+    self.stop.store(true, Ordering::Release);
+    if let Some(thread) = self.thread.take() {
+      thread.thread().unpark();
+      if thread.join().is_err() {
+        warn!("job-control resource wakeup thread panicked");
+      }
+    }
+  }
+}
+
 impl Tracer {
   pub fn spawn(
     self,
@@ -228,7 +313,10 @@ impl Tracer {
     let seccomp_bpf = self.seccomp_bpf;
     let req_tx = self.req_tx.clone();
     let blocking = self.blocking();
+    let job_control_enabled = self.job_control.is_some();
     let tx = self.msg_tx.clone();
+    let wakeup_state = Arc::new(JobControlWakeupState::default());
+    let blocking_waitpid = Arc::new(AtomicBool::new(false));
     let (tid_tx, tid_rx) = std::sync::mpsc::sync_channel(1);
     let tracer_thread = tokio::task::spawn_blocking({
       move || {
@@ -245,13 +333,22 @@ impl Tracer {
               nix::sys::signal::SIGUSR1,
               &SigAction::new(
                 nix::sys::signal::SigHandler::Handler(empty_sighandler),
-                SaFlags::SA_SIGINFO,
+                SaFlags::empty(),
                 SigSet::empty(),
               ),
             )?;
           }
         }
-        let inner = TracerInner::new(self, breakpoints, output)?;
+        let _job_control_wakeup = (blocking && job_control_enabled)
+          .then(|| {
+            JobControlWakeup::spawn(
+              current_thread,
+              wakeup_state.clone(),
+              blocking_waitpid.clone(),
+            )
+          })
+          .transpose()?;
+        let inner = TracerInner::new(self, breakpoints, output, wakeup_state, blocking_waitpid)?;
         let result = tokio::runtime::Handle::current()
           .block_on(async move { inner.run(args, token.req_rx).await });
         if let Err(e) = &result {
@@ -277,7 +374,13 @@ impl Tracer {
   fn attach_for_test(self, pid: Pid) -> tokio::task::JoinHandle<color_eyre::Result<()>> {
     let tx = self.msg_tx.clone();
     tokio::task::spawn_blocking(move || {
-      let inner = TracerInner::new(self, Arc::new(RwLock::new(BTreeMap::new())), None)?;
+      let inner = TracerInner::new(
+        self,
+        Arc::new(RwLock::new(BTreeMap::new())),
+        None,
+        Arc::new(JobControlWakeupState::default()),
+        Arc::new(AtomicBool::new(false)),
+      )?;
       let result = inner.run_attached(pid);
       if let Err(e) = &result {
         let _ = tx.send(TracerMessage::FatalError(e.to_string()));
@@ -342,11 +445,7 @@ impl RunningTracer {
   }
 
   fn blocking_mode_notify_tracer(&self) -> Result<(), Errno> {
-    let r = unsafe { pthread_kill(self.tid, nix::sys::signal::SIGUSR1 as c_int) };
-    if r != 0 {
-      return Err(nix::errno::Errno::from_raw(r));
-    }
-    Ok(())
+    notify_tracer_thread(self.tid)
   }
 
   pub fn request_process_detach(

--- a/crates/tracexec-backend-ptrace/src/ptrace/tracer/inner.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace/tracer/inner.rs
@@ -22,6 +22,10 @@ use std::{
   sync::{
     Arc,
     RwLock,
+    atomic::{
+      AtomicBool,
+      Ordering,
+    },
   },
   time::Duration,
 };
@@ -160,6 +164,11 @@ use crate::{
       read_env,
       read_string,
     },
+    job_control::{
+      Admission,
+      AutoJobController,
+      JobControlWakeupState,
+    },
     syscall::SyscallInfo,
     tracer::{
       PendingRequest,
@@ -182,6 +191,9 @@ pub struct TracerInner {
   filter: BitFlags<TracerEventDetailsKind>,
   baseline: Arc<BaselineInfo>,
   seccomp_bpf: SeccompBpf,
+  job_control: RefCell<Option<AutoJobController>>,
+  wakeup_state: Arc<JobControlWakeupState>,
+  blocking_waitpid: Arc<AtomicBool>,
   msg_tx: UnboundedSender<TracerMessage>,
   user: Option<User>,
   polling_interval: Option<Duration>,
@@ -211,6 +223,8 @@ impl TracerInner {
     tracer: Tracer,
     breakpoints: Arc<RwLock<BTreeMap<u32, BreakPoint>>>,
     output: Option<Box<PrinterOut>>,
+    wakeup_state: Arc<JobControlWakeupState>,
+    blocking_waitpid: Arc<AtomicBool>,
   ) -> color_eyre::Result<Self> {
     let Tracer {
       with_tty,
@@ -220,6 +234,7 @@ impl TracerInner {
       filter,
       baseline,
       seccomp_bpf,
+      job_control,
       msg_tx,
       user,
       req_tx: _,
@@ -237,6 +252,9 @@ impl TracerInner {
       filter,
       baseline,
       seccomp_bpf,
+      job_control: RefCell::new(job_control.map(|_| AutoJobController::new(wakeup_state.clone()))),
+      wakeup_state,
+      blocking_waitpid,
       msg_tx,
       user,
       polling_interval,
@@ -440,6 +458,9 @@ impl TracerInner {
             while let Ok(req) = req_rx.try_recv() {
               request_handler!(req, pending_guards);
             }
+            // In job-control mode a lightweight timer interrupts blocking
+            // waitpid so queued jobs can be reconsidered as pressure changes.
+            self.resume_job_controlled_processes(&mut pending_guards)?;
           }
           Err(e) => {
             return Err(e.into());
@@ -498,7 +519,13 @@ impl TracerInner {
       waitpid_flags |= WaitPidFlag::WNOHANG;
     }
     loop {
+      if blocking {
+        self.blocking_waitpid.store(true, Ordering::Release);
+      }
       let status = engine.next_event(Some(waitpid_flags));
+      if blocking {
+        self.blocking_waitpid.store(false, Ordering::Release);
+      }
       if matches!(status, Err(Errno::EINTR)) {
         if blocking {
           return Err(WaitpidHandlerError::Interrupted);
@@ -525,7 +552,7 @@ impl TracerInner {
               .context(OtherSnafu)?;
           } else {
             self
-              .on_syscall_exit(guard, info, pending_guards, timestamp)
+              .on_syscall_exit(guard, info, pending_guards, timestamp, root_child)
               .context(OtherSnafu)?;
           }
         }
@@ -572,6 +599,9 @@ impl TracerInner {
           let pid = guard.pid(); // The TGID for the new process after exec
           // The (former) thread id that called exec
           let former_tid = guard.former_tid.context(OSSnafu)?;
+          if let Some(job_control) = self.job_control.borrow_mut().as_mut() {
+            job_control.process_execed(former_tid, pid);
+          }
           let mut store = self.store.borrow_mut();
           let p = if former_tid == pid {
             let p = store.get_current_mut(pid).unwrap();
@@ -665,6 +695,9 @@ impl TracerInner {
           let new_child = guard.child().context(OSSnafu)?;
           let pid = guard.pid();
           trace!("ptrace fork/clone event, pid: {pid}, child: {new_child}");
+          if let Some(job_control) = self.job_control.borrow_mut().as_mut() {
+            job_control.process_spawned(pid, new_child);
+          }
           if self.filter.intersects(TracerEventDetailsKind::NewChild) {
             let store = self.store.borrow();
             let parent = store.get_current(pid).unwrap();
@@ -737,6 +770,7 @@ impl TracerInner {
         }
         PtraceWaitPidEvent::Signaled { pid, signal: sig } => {
           debug!("signaled: {pid}, {:?}", sig);
+          self.job_control_process_exited(pid, pending_guards);
           let mut store = self.store.borrow_mut();
           if let Some(state) = store.get_current_mut(pid) {
             state.status = ProcessStatus::Exited(ProcessExit::Signal(sig));
@@ -772,6 +806,7 @@ impl TracerInner {
         PtraceWaitPidEvent::Exited { pid, code } => {
           // pid could also be a not traced subprocess.
           trace!("exited: pid {}, code {:?}", pid, code);
+          self.job_control_process_exited(pid, pending_guards);
           let mut store = self.store.borrow_mut();
           if let Some(state) = store.get_current_mut(pid) {
             state.status = ProcessStatus::Exited(ProcessExit::Code(code));
@@ -812,13 +847,61 @@ impl TracerInner {
         PtraceWaitPidEvent::Continued(_) => unreachable!(),
         PtraceWaitPidEvent::StillAlive => break,
       }
+      if blocking && self.wakeup_state.has_waiting_jobs() {
+        // Child events, especially job completion, are the fastest signal that
+        // capacity is available. Do not wait for the resource timer before
+        // replacing a finished job.
+        self
+          .resume_job_controlled_processes(pending_guards)
+          .context(OtherSnafu)?;
+      }
       if !blocking && counter > 100 {
         // Give up if we have handled 100 events, so that we have a chance to handle other events
         debug!("yielding after 100 events");
         break;
       }
     }
+    self
+      .resume_job_controlled_processes(pending_guards)
+      .context(OtherSnafu)?;
     Ok(ControlFlow::Continue(()))
+  }
+
+  fn job_control_process_exited<'a>(
+    &self,
+    pid: Pid,
+    pending_guards: &mut HashMap<Pid, PtraceStopGuard<'a>>,
+  ) {
+    let was_waiting = self
+      .job_control
+      .borrow_mut()
+      .as_mut()
+      .is_some_and(|job_control| job_control.process_exited(pid));
+    if was_waiting {
+      pending_guards.remove(&pid);
+    }
+  }
+
+  fn resume_job_controlled_processes<'a>(
+    &self,
+    pending_guards: &mut HashMap<Pid, PtraceStopGuard<'a>>,
+  ) -> color_eyre::Result<()> {
+    let ready = self
+      .job_control
+      .borrow_mut()
+      .as_mut()
+      .map(AutoJobController::jobs_ready_to_run)
+      .unwrap_or_default();
+    for pid in ready {
+      let guard = pending_guards
+        .remove(&pid)
+        .ok_or_else(|| color_eyre::eyre::eyre!("missing job-control stop guard for {pid}"))?;
+      if let Some(state) = self.store.borrow_mut().get_current_mut(pid) {
+        state.status = ProcessStatus::Running;
+      }
+      guard.seccomp_aware_cont_syscall(true)?;
+    }
+    Ok(())
   }
 
   fn read_syscall_info(
@@ -1034,6 +1117,7 @@ impl TracerInner {
     info: SyscallInfo,
     pending_guards: &mut HashMap<Pid, PtraceStopGuard<'a>>,
     timestamp: DateTime<Local>,
+    root_child: Pid,
   ) -> color_eyre::Result<()> {
     // SYSCALL EXIT
     // trace!("post syscall {}", p.syscall);
@@ -1123,6 +1207,19 @@ impl TracerInner {
         p.exec_data = None;
         // update comm
         p.comm = read_comm(pid)?;
+
+        if exec_result == 0
+          && pid != root_child
+          && self
+            .job_control
+            .borrow_mut()
+            .as_mut()
+            .is_some_and(|job_control| job_control.admit(pid) == Admission::Wait)
+        {
+          p.status = ProcessStatus::JobControlQueued;
+          pending_guards.insert(pid, guard.into());
+          return Ok(());
+        }
       }
       _ => (),
     }
@@ -1429,7 +1526,10 @@ impl TracerInner {
 mod tests {
   use std::{
     collections::BTreeMap,
-    sync::Arc,
+    sync::{
+      Arc,
+      atomic::AtomicBool,
+    },
   };
 
   use enumflags2::BitFlags;
@@ -1468,7 +1568,10 @@ mod tests {
   };
 
   use super::TracerInner;
-  use crate::ptrace::BuildPtraceTracer;
+  use crate::ptrace::{
+    BuildPtraceTracer,
+    job_control::JobControlWakeupState,
+  };
 
   fn build_inner(
     mut modifier_args: ModifierArgs,
@@ -1495,6 +1598,8 @@ mod tests {
       tracer,
       Arc::new(std::sync::RwLock::new(BTreeMap::new())),
       None,
+      Arc::new(JobControlWakeupState::default()),
+      Arc::new(AtomicBool::new(false)),
     )
     .unwrap();
     (inner, msg_rx)

--- a/crates/tracexec-backend-ptrace/src/ptrace/tracer/state.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace/tracer/state.rs
@@ -58,6 +58,7 @@ pub enum ProcessStatus {
   Running,
   Exited(ProcessExit),
   BreakPointHit,
+  JobControlQueued,
   Detached,
 }
 

--- a/crates/tracexec-backend-ptrace/src/ptrace/tracer/test.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace/tracer/test.rs
@@ -28,7 +28,10 @@ use tracexec_core::{
       LogModeArgs,
       ModifierArgs,
     },
-    options::SeccompBpf,
+    options::{
+      JobControl,
+      SeccompBpf,
+    },
   },
   event::{
     ExecSyscall,
@@ -157,6 +160,43 @@ fn spawn_rejects_token_from_another_tracer() {
   assert!(err.to_string().contains("does not belong to this tracer"));
 }
 
+#[test]
+fn auto_job_control_uses_blocking_waitpid() {
+  let (msg_tx, _msg_rx) = tokio::sync::mpsc::unbounded_channel();
+  let tracing_args = LogModeArgs::default();
+  let (tracer, _token) = TracerBuilder::new()
+    .mode(TracerMode::Log { foreground: false })
+    .tracer_tx(msg_tx)
+    .baseline(Arc::new(BaselineInfo::new().unwrap()))
+    .printer_from_cli(&tracing_args)
+    .seccomp_bpf(SeccompBpf::On)
+    .ptrace_blocking(true)
+    .job_control(Some(JobControl::Auto))
+    .build_ptrace()
+    .unwrap();
+
+  assert!(tracer.polling_interval.is_none());
+}
+
+#[test]
+fn auto_job_control_respects_explicit_polling() {
+  let (msg_tx, _msg_rx) = tokio::sync::mpsc::unbounded_channel();
+  let tracing_args = LogModeArgs::default();
+  let (tracer, _token) = TracerBuilder::new()
+    .mode(TracerMode::Log { foreground: false })
+    .tracer_tx(msg_tx)
+    .baseline(Arc::new(BaselineInfo::new().unwrap()))
+    .printer_from_cli(&tracing_args)
+    .seccomp_bpf(SeccompBpf::On)
+    .ptrace_blocking(false)
+    .ptrace_polling_delay(Some(25))
+    .job_control(Some(JobControl::Auto))
+    .build_ptrace()
+    .unwrap();
+
+  assert_eq!(tracer.polling_interval, Some(Duration::from_micros(25)));
+}
+
 #[traced_test]
 #[rstest]
 #[case(true)]
@@ -273,6 +313,64 @@ async fn tracer_emits_exec_event(
     }
   }
   panic!("Corresponding exec event not found")
+}
+
+#[traced_test]
+#[rstest]
+#[file_serial]
+#[tokio::test]
+async fn tracer_auto_job_control_runs_subprocesses(sh_executable: PathBuf) {
+  let tracer_mode = TracerMode::Log { foreground: false };
+  let tracing_args = LogModeArgs::default();
+  let (msg_tx, msg_rx) = tokio::sync::mpsc::unbounded_channel();
+  let baseline = BaselineInfo::new().unwrap();
+  let (tracer, token) = TracerBuilder::new()
+    .mode(tracer_mode)
+    .modifier(Default::default())
+    .tracer_tx(msg_tx)
+    .baseline(Arc::new(baseline))
+    .printer_from_cli(&tracing_args)
+    .seccomp_bpf(SeccompBpf::Auto)
+    .job_control(Some(JobControl::Auto))
+    .build_ptrace()
+    .unwrap();
+
+  let sleep_executable = find_executable("sleep");
+  let sleep_executable = sleep_executable.to_string_lossy();
+  let subprocesses = std::thread::available_parallelism()
+    .map(usize::from)
+    .unwrap_or(1)
+    .saturating_mul(2)
+    .clamp(2, 32);
+  let script = std::iter::repeat_n(format!("{sleep_executable} 0.2 &"), subprocesses)
+    .chain(["wait".to_string()])
+    .collect::<Vec<_>>()
+    .join(" ");
+  let events = run_exe_and_collect_msgs(
+    tracer,
+    msg_rx,
+    token,
+    vec![
+      sh_executable.to_string_lossy().into_owned(),
+      "-c".to_string(),
+      script,
+    ],
+  )
+  .await;
+
+  assert!(events.iter().any(|event| {
+    matches!(
+      event,
+      TracerMessage::Event(TracerEvent {
+        details: TracerEventDetails::TraceeExit {
+          signal: None,
+          exit_code: 0,
+          ..
+        },
+        ..
+      })
+    )
+  }));
 }
 
 #[traced_test]

--- a/crates/tracexec-core/src/cli.rs
+++ b/crates/tracexec-core/src/cli.rs
@@ -379,6 +379,7 @@ mod tests {
     options::{
       Color,
       ExportFormat,
+      JobControl,
       SeccompBpf,
     },
   };
@@ -547,6 +548,7 @@ mod tests {
     let config = Config {
       ptrace: Some(PtraceConfig {
         seccomp_bpf: Some(SeccompBpf::On),
+        job_control: Some(JobControl::Auto),
       }),
       modifier: Some(ModifierConfig {
         successful_only: Some(true),
@@ -572,6 +574,7 @@ mod tests {
       assert!(tracing_args.show_interpreter);
       assert!(modifier_args.successful_only);
       assert_eq!(ptrace_args.seccomp_bpf, SeccompBpf::On);
+      assert_eq!(ptrace_args.job_control, Some(JobControl::Auto));
     } else {
       panic!("Expected Log command");
     }
@@ -603,6 +606,7 @@ mod tests {
     let config = Config {
       ptrace: Some(PtraceConfig {
         seccomp_bpf: Some(SeccompBpf::Off),
+        job_control: None,
       }),
       modifier: Some(ModifierConfig {
         successful_only: Some(true),

--- a/crates/tracexec-core/src/cli/args.rs
+++ b/crates/tracexec-core/src/cli/args.rs
@@ -32,6 +32,7 @@ use super::{
   options::{
     ActivePane,
     AppLayout,
+    JobControl,
     SeccompBpf,
   },
 };
@@ -55,6 +56,12 @@ pub struct PtraceArgs {
     help = "Polling interval, in microseconds. -1(default) disables polling."
   )]
   pub polling_interval: Option<i64>,
+  #[clap(
+    long,
+    value_name = "MODE",
+    help = "Dynamically control subprocess parallelism according to system CPU and memory load"
+  )]
+  pub job_control: Option<JobControl>,
 }
 
 #[derive(Args, Debug, Default, Clone)]
@@ -123,6 +130,9 @@ impl PtraceArgs {
       && self.seccomp_bpf == SeccompBpf::Auto
     {
       self.seccomp_bpf = setting;
+    }
+    if self.job_control.is_none() {
+      self.job_control = config.job_control;
     }
   }
 }
@@ -670,20 +680,36 @@ mod tests {
     let mut args = PtraceArgs {
       seccomp_bpf: SeccompBpf::Auto,
       polling_interval: None,
+      job_control: None,
     };
 
     let cfg = PtraceConfig {
       seccomp_bpf: Some(SeccompBpf::On),
+      job_control: Some(JobControl::Auto),
     };
 
     args.merge_config(cfg);
     assert_eq!(args.seccomp_bpf, SeccompBpf::On);
+    assert_eq!(args.job_control, Some(JobControl::Auto));
   }
 
   #[test]
   fn test_ptrace_args_cli_parse() {
-    let cli = TestCli::<PtraceArgs>::parse_from(["test", "--polling-interval", "100"]);
+    let cli = TestCli::<PtraceArgs>::parse_from([
+      "test",
+      "--polling-interval",
+      "100",
+      "--job-control",
+      "auto",
+    ]);
     assert_eq!(cli.args.polling_interval, Some(100));
+    assert_eq!(cli.args.job_control, Some(JobControl::Auto));
+  }
+
+  #[test]
+  fn test_ptrace_args_rejects_unknown_job_control_mode() {
+    let result = TestCli::<PtraceArgs>::try_parse_from(["test", "--job-control", "fixed"]);
+    assert!(result.is_err());
   }
 
   /* ---------------------------- ModifierArgs ----------------------------- */

--- a/crates/tracexec-core/src/cli/config.rs
+++ b/crates/tracexec-core/src/cli/config.rs
@@ -22,6 +22,7 @@ use tracing::warn;
 use super::options::{
   ActivePane,
   AppLayout,
+  JobControl,
   SeccompBpf,
 };
 use crate::{
@@ -147,6 +148,7 @@ pub struct TimestampConfig {
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
 pub struct PtraceConfig {
   pub seccomp_bpf: Option<SeccompBpf>,
+  pub job_control: Option<JobControl>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]
@@ -344,9 +346,13 @@ inline_format = "%H:%M:%S"
 
   #[test]
   fn test_ptrace_config_roundtrip() {
-    let toml_str = r#"seccomp_bpf = "Auto""#;
+    let toml_str = r#"
+seccomp_bpf = "Auto"
+job_control = "Auto"
+"#;
     let cfg: PtraceConfig = toml::from_str(toml_str).unwrap();
     assert_eq!(cfg.seccomp_bpf.unwrap(), SeccompBpf::Auto);
+    assert_eq!(cfg.job_control.unwrap(), JobControl::Auto);
   }
 
   #[test]

--- a/crates/tracexec-core/src/cli/options.rs
+++ b/crates/tracexec-core/src/cli/options.rs
@@ -34,6 +34,12 @@ pub enum SeccompBpf {
   Off,
 }
 
+#[derive(Debug, Clone, Copy, ValueEnum, PartialEq, Eq, Display, Deserialize, Serialize)]
+#[strum(serialize_all = "kebab-case")]
+pub enum JobControl {
+  Auto,
+}
+
 #[derive(
   Debug, Clone, Copy, ValueEnum, PartialEq, Eq, Display, Default, Deserialize, Serialize,
 )]

--- a/crates/tracexec-core/src/tracer.rs
+++ b/crates/tracexec-core/src/tracer.rs
@@ -29,7 +29,10 @@ use crate::{
       ModifierArgs,
       PtraceArgs,
     },
-    options::SeccompBpf,
+    options::{
+      JobControl,
+      SeccompBpf,
+    },
   },
   elevate::EnvVars,
   event::{
@@ -116,6 +119,7 @@ pub struct TracerBuilder {
   pub baseline: Option<Arc<BaselineInfo>>,
   // --- ptrace specific ---
   pub seccomp_bpf: SeccompBpf,
+  pub job_control: Option<JobControl>,
   pub ptrace_polling_delay: Option<u64>,
   pub ptrace_blocking: Option<bool>,
   pub tracee_env: Option<EnvVars>,
@@ -158,6 +162,7 @@ impl TracerBuilder {
   pub fn ptrace_options(self, args: &PtraceArgs) -> Self {
     self
       .seccomp_bpf(args.seccomp_bpf)
+      .job_control(args.job_control)
       .ptrace_blocking(args.polling_interval.is_none_or(|value| value < 0))
       .ptrace_polling_delay(
         args
@@ -173,6 +178,14 @@ impl TracerBuilder {
   /// This option is not used in eBPF tracer.
   pub fn seccomp_bpf(mut self, seccomp_bpf: SeccompBpf) -> Self {
     self.seccomp_bpf = seccomp_bpf;
+    self
+  }
+
+  /// Enables ptrace subprocess job control.
+  ///
+  /// This option is not used in the eBPF tracer.
+  pub fn job_control(mut self, job_control: Option<JobControl>) -> Self {
+    self.job_control = job_control;
     self
   }
 
@@ -403,10 +416,12 @@ mod tests {
     let polling = TracerBuilder::new().ptrace_options(&PtraceArgs {
       seccomp_bpf: SeccompBpf::Off,
       polling_interval: Some(250),
+      job_control: Some(JobControl::Auto),
     });
     assert_eq!(polling.seccomp_bpf, SeccompBpf::Off);
     assert_eq!(polling.ptrace_blocking, Some(false));
     assert_eq!(polling.ptrace_polling_delay, Some(250));
+    assert_eq!(polling.job_control, Some(JobControl::Auto));
 
     let no_delay = TracerBuilder::new().ptrace_options(&PtraceArgs {
       polling_interval: Some(0),


### PR DESCRIPTION
PoC for https://github.com/kxxt/tracexec/issues/32.

tracexec can be used to control parallelism of sub-processes to help avoiding pressure stalls or even OOM.

I think I will become willing to merge this if it could exceed the native performance of `make -j$(nproc)` in a kernel build.

Currently it is slightly slower than it.

```
# 1:17.77 total
make -j32
```

```
# 1:20.69 total
~/repos/tracexec/target/release/tracexec log --output=/dev/null --job-control=auto -- make -j  
```