### PR TITLE
refactor: use test-that for declarative assertion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3053,6 +3053,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "test-that"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291f228058142bae421e0b4b014a7b18edd6137629550cc15da37feed66a7db6"
+dependencies = [
+ "num-traits",
+ "regex",
+ "test-that-macro",
+]
+
+[[package]]
+name = "test-that-macro"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6453b0f4c66f6ed93ac9ababa97e347a22f5556180d19808bb6d796522eef5d"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3237,6 +3258,7 @@ dependencies = [
  "signal-hook-tokio",
  "strum 0.27.2",
  "tempfile",
+ "test-that",
  "tokio",
  "tracexec-backend-ebpf",
  "tracexec-backend-ptrace",
@@ -3272,6 +3294,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "tempfile",
+ "test-that",
  "tokio",
  "tracexec-core",
  "tracing",
@@ -3294,6 +3317,7 @@ dependencies = [
  "rusty-fork",
  "serial_test",
  "snafu",
+ "test-that",
  "tokio",
  "tracexec-core",
  "tracing",
@@ -3331,6 +3355,7 @@ dependencies = [
  "snafu",
  "strum 0.27.2",
  "tempfile",
+ "test-that",
  "tokio",
  "toml",
  "tracing",
@@ -3344,6 +3369,7 @@ dependencies = [
  "nix 0.31.3",
  "serde",
  "serde_json",
+ "test-that",
  "tokio",
  "tracexec-core",
  "tracing",
@@ -3367,6 +3393,7 @@ dependencies = [
  "prost",
  "serde",
  "strum 0.27.2",
+ "test-that",
  "tokio",
  "tracexec-core",
  "tracing",
@@ -3396,6 +3423,7 @@ dependencies = [
  "shell-quote",
  "shell-words",
  "tempfile",
+ "test-that",
  "tokio",
  "tokio-util",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ tracing-test = "0.2.4"
 serial_test = { version = "3.1.1", features = ["file_locks"] }
 rusty-fork = "0.3.1"
 tempfile = "3.24.0"
+test-that = "0.5.2"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }
@@ -128,6 +129,7 @@ tracexec-backend-ebpf = { workspace = true, optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.14"
+test-that = { workspace = true }
 serial_test = { workspace = true }
 predicates = { workspace = true }
 nix = { workspace = true }

--- a/crates/tracexec-backend-ebpf/Cargo.toml
+++ b/crates/tracexec-backend-ebpf/Cargo.toml
@@ -53,6 +53,7 @@ rusty-fork = { workspace = true }
 rstest = { workspace = true }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
+test-that = { workspace = true }
 
 [[bin]]
 name = "compat-exec"

--- a/crates/tracexec-backend-ebpf/src/bin/verifier_complexity.rs
+++ b/crates/tracexec-backend-ebpf/src/bin/verifier_complexity.rs
@@ -585,6 +585,8 @@ fn prepare_compat_execveat_fentry(open_skel: &mut OpenTracexecSystemSkel<'_>) ->
 
 #[cfg(test)]
 mod tests {
+  use test_that::prelude::*;
+
   use super::*;
 
   #[test]
@@ -628,7 +630,7 @@ mod tests {
     .expect("processed metrics should still parse");
 
     assert_eq!(metrics.stack_depth, None);
-    assert!(metrics.stack_depths.is_empty());
+    assert_that!(metrics.stack_depths, empty());
     assert_eq!(metrics.insns_processed, 103);
   }
 }

--- a/crates/tracexec-backend-ebpf/src/event.rs
+++ b/crates/tracexec-backend-ebpf/src/event.rs
@@ -82,6 +82,7 @@ impl From<Path> for OutputMsg {
 
 #[cfg(test)]
 mod tests {
+  use test_that::prelude::*;
   use tracexec_core::{
     event::{
       BpfError,
@@ -119,7 +120,7 @@ mod tests {
       error: None,
     };
     let out: OutputMsg = path.into();
-    assert!(out.as_ref().contains("[err: bpf error]"));
+    assert_that!(out.as_ref(), contains_substring("[err: bpf error]"));
     assert!(matches!(out, OutputMsg::PartialOk(_)));
   }
 

--- a/crates/tracexec-backend-ebpf/src/process_tracker.rs
+++ b/crates/tracexec-backend-ebpf/src/process_tracker.rs
@@ -120,6 +120,7 @@ impl ProcessTracker {
 #[cfg(test)]
 mod tests {
   use nix::unistd::Pid;
+  use test_that::prelude::*;
   use tracexec_core::event::EventId;
 
   use super::ProcessTracker;
@@ -135,7 +136,7 @@ mod tests {
     assert_eq!(events[0], EventId::new(1));
     assert_eq!(events[1], EventId::new(2));
     tracker.remove(pid);
-    assert!(tracker.maybe_associated_events(pid).is_none());
+    assert_that!(tracker.maybe_associated_events(pid), none());
   }
 
   #[test]
@@ -174,7 +175,10 @@ mod tests {
 
     tracker.add(pid);
 
-    assert_eq!(tracker.maybe_associated_events(pid), Some([].as_slice()));
+    assert_that!(
+      tracker.maybe_associated_events(pid),
+      some(points_to(empty())),
+    );
   }
 
   #[test]

--- a/crates/tracexec-backend-ebpf/src/tracer.rs
+++ b/crates/tracexec-backend-ebpf/src/tracer.rs
@@ -1092,6 +1092,7 @@ mod tests {
   use enumflags2::BitFlags;
   use rstest::rstest;
   use serial_test::file_serial;
+  use test_that::prelude::*;
   use tokio::sync::mpsc::unbounded_channel;
   use tracexec_core::printer::{
     ColorLevel,
@@ -1184,7 +1185,7 @@ mod tests {
       BitFlags::from_flag(BpfEventFlags::FDS_PROBE_FAILURE),
     );
 
-    assert!(fds.error.is_some());
+    assert_that!(fds.error, some(anything()));
   }
 
   #[test]
@@ -1198,9 +1199,9 @@ mod tests {
     );
 
     let fd = fds.fdinfo.get(&3).unwrap();
-    assert!(fd.flags.ok().is_some());
+    assert_that!(fd.flags.ok(), some(anything()));
     assert!(fd.flags.contains(OFlag::O_RDONLY));
-    assert!(fds.error.is_none());
+    assert_that!(fds.error, none());
   }
 
   #[test]
@@ -1212,7 +1213,7 @@ mod tests {
 
     let fd = fds.fdinfo.get(&3).unwrap();
     assert!(matches!(&fd.path, OutputMsg::Ok(path) if path.as_ref() == "pipe:[0]"));
-    assert!(fds.error.is_none());
+    assert_that!(fds.error, none());
   }
 
   #[test]
@@ -1271,7 +1272,7 @@ mod tests {
     )
     .unwrap();
 
-    assert!(rx.try_recv().is_err());
+    assert_that!(rx.try_recv(), err(anything()));
   }
 
   fn run_ebpf_and_collect(
@@ -1453,7 +1454,12 @@ mod tests {
 
     let meta = std::fs::metadata(&profraw_path).expect("profraw file missing");
     // Minimum: 128-byte header
-    assert!(meta.len() >= 128, "profraw too small: {} bytes", meta.len());
+    assert_that!(
+      meta.len(),
+      ge(128),
+      "profraw too small: {} bytes",
+      meta.len()
+    );
 
     // Verify magic and version
     let data = std::fs::read(&profraw_path).unwrap();
@@ -1518,8 +1524,12 @@ mod tests {
       index.display()
     );
     let html = std::fs::read_to_string(&index).unwrap();
-    assert!(
-      html.contains("<!doctype html>") || html.contains("<!DOCTYPE html>"),
+    assert_that!(
+      html,
+      any!(
+        contains_substring("<!doctype html>"),
+        contains_substring("<!DOCTYPE html>")
+      ),
       "index.html doesn't look like HTML"
     );
 
@@ -1564,8 +1574,12 @@ mod tests {
       lcov_path.display()
     );
     let lcov = std::fs::read_to_string(&lcov_path).unwrap();
-    assert!(
-      lcov.contains("SF:") && lcov.contains("end_of_record"),
+    assert_that!(
+      lcov,
+      all!(
+        contains_substring("SF:"),
+        contains_substring("end_of_record"),
+      ),
       "LCOV output doesn't look like a valid tracefile"
     );
 

--- a/crates/tracexec-backend-ebpf/tests/exec_events.rs
+++ b/crates/tracexec-backend-ebpf/tests/exec_events.rs
@@ -33,6 +33,7 @@ use rstest::{
   rstest,
 };
 use serial_test::file_serial;
+use test_that::prelude::*;
 #[cfg(target_arch = "x86_64")]
 use tracexec_backend_ebpf::probe::should_load_compat_syscall_hooks;
 use tracexec_backend_ebpf::{
@@ -723,7 +724,7 @@ fn test_exec_emits_auxiliary_events(sh_executable: PathBuf) -> color_eyre::Resul
       assert_eq!(capture.exec.header.r#type, event_type::SYSEXIT_EVENT);
       assert_eq!(capture.exec.header.pid, capture.pid);
       assert_eq!(capture.exec.ret, 0);
-      assert!(!capture.strings.is_empty(), "expected STRING_EVENTs");
+      assert_that!(capture.strings, not(empty()), "expected STRING_EVENTs");
       assert!(
         capture.strings.iter().any(|s| s == "true"),
         "expected STRING_EVENT containing argv 'true'"
@@ -732,16 +733,17 @@ fn test_exec_emits_auxiliary_events(sh_executable: PathBuf) -> color_eyre::Resul
         capture.strings.iter().any(|s| s.starts_with("PATH=")),
         "expected STRING_EVENT containing PATH env"
       );
-      assert!(!capture.path_events.is_empty(), "expected PATH_EVENTs");
-      assert!(
-        !capture.path_segments.is_empty(),
+      assert_that!(capture.path_events, not(empty()), "expected PATH_EVENTs");
+      assert_that!(
+        capture.path_segments,
+        not(empty()),
         "expected PATH_SEGMENT_EVENTs"
       );
       assert!(
         capture.path_segments.iter().any(|s| !s.is_empty()),
         "expected non-empty path segments"
       );
-      assert!(!capture.fd_events.is_empty(), "expected FD_EVENTs");
+      assert_that!(capture.fd_events, not(empty()), "expected FD_EVENTs");
       assert!(
         capture
           .fd_events
@@ -751,7 +753,7 @@ fn test_exec_emits_auxiliary_events(sh_executable: PathBuf) -> color_eyre::Resul
       );
       let cred_err = (capture.exec.header.flags & (BpfEventFlags::CRED_READ_ERR as u32)) != 0;
       if !cred_err {
-        assert!(!capture.groups_sizes.is_empty(), "expected GROUPS_EVENTs");
+        assert_that!(capture.groups_sizes, not(empty()), "expected GROUPS_EVENTs");
         assert!(
           capture.groups_sizes.iter().any(|s| *s > 0),
           "expected non-empty GROUPS_EVENT payload"
@@ -772,8 +774,9 @@ fn test_exec_reports_pseudo_filesystem_fds_across_exec() -> color_eyre::Result<(
     prepare_execve_kprobe_kretprobe,
     |skel| {
       let capture = run_binary_and_collect_aux(skel, &bin, &[], Duration::from_secs(4))?;
-      assert!(
-        capture.exec_events.len() >= 2,
+      assert_that!(
+        capture.exec_events.len(),
+        ge(2),
         "fixture should exec once after opening special fds"
       );
 
@@ -788,14 +791,15 @@ fn test_exec_reports_pseudo_filesystem_fds_across_exec() -> color_eyre::Result<(
         .iter()
         .filter(|event| event.header.eid == reexec_eid)
         .collect::<Vec<_>>();
-      assert!(!reexec_fds.is_empty(), "missing fd events for re-exec");
+      assert_that!(reexec_fds, not(empty()), "missing fd events for re-exec");
 
       let pipe_fds = reexec_fds
         .iter()
         .filter(|event| fd_fstype(event) == "pipefs" && event.uses_d_dname != 0)
         .collect::<Vec<_>>();
-      assert!(
-        pipe_fds.len() >= 2,
+      assert_that!(
+        pipe_fds.len(),
+        ge(2),
         "expected both inherited pipe fds, got {}",
         pipe_fds.len()
       );
@@ -812,8 +816,9 @@ fn test_exec_reports_pseudo_filesystem_fds_across_exec() -> color_eyre::Result<(
         .iter()
         .filter(|event| fd_fstype(event) == "sockfs" && event.uses_d_dname != 0)
         .collect::<Vec<_>>();
-      assert!(
-        socket_fds.len() >= 2,
+      assert_that!(
+        socket_fds.len(),
+        ge(2),
         "expected both inherited socketpair fds, got {}",
         socket_fds.len()
       );
@@ -844,10 +849,9 @@ fn test_exec_reports_pseudo_filesystem_fds_across_exec() -> color_eyre::Result<(
         .expect("expected inherited namespace fd");
       assert_eq!(ns_fd.uses_d_dname, 1);
       assert_eq!(fd_pseudo_name(ns_fd), "mnt");
-      assert!(
-        rendered_fd_path(&capture, ns_fd)
-          .as_ref()
-          .starts_with("mnt:["),
+      assert_that!(
+        rendered_fd_path(&capture, ns_fd).as_ref(),
+        starts_with("mnt:["),
         "namespace fd should render as mnt:[ino]"
       );
 

--- a/crates/tracexec-backend-ptrace/Cargo.toml
+++ b/crates/tracexec-backend-ptrace/Cargo.toml
@@ -29,6 +29,7 @@ snafu = { workspace = true }
 
 [dev-dependencies]
 rstest = { workspace = true }
+test-that = { workspace = true }
 tracing-test = { workspace = true }
 predicates = { workspace = true }
 serial_test = { workspace = true }

--- a/crates/tracexec-backend-ptrace/src/ptrace/tracer/inner.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace/tracer/inner.rs
@@ -1440,6 +1440,7 @@ mod tests {
       getpid,
     },
   };
+  use test_that::prelude::*;
   use tokio::sync::mpsc::UnboundedReceiver;
   use tracexec_core::{
     cli::{
@@ -1545,7 +1546,7 @@ mod tests {
     else {
       panic!("unexpected message: {received:?}");
     };
-    assert!(msg.contains("Empty argv"));
+    assert_that!(msg, contains_substring("Empty argv"));
 
     inner
       .warn_for_envp::<Vec<i32>>(&Err(Errno::EPERM), Pid::from_raw(1))
@@ -1558,7 +1559,7 @@ mod tests {
     else {
       panic!("unexpected message: {received:?}");
     };
-    assert!(msg.contains("Failed to read envp"));
+    assert_that!(msg, contains_substring("Failed to read envp"));
   }
 
   #[test]
@@ -1576,7 +1577,7 @@ mod tests {
     else {
       panic!("unexpected message: {received:?}");
     };
-    assert!(msg.contains("Failed to read filename"));
+    assert_that!(msg, contains_substring("Failed to read filename"));
   }
 
   #[test]
@@ -1585,7 +1586,7 @@ mod tests {
     inner
       .warn_for_argv::<i32>(&Err(Errno::EPERM), Pid::from_raw(1))
       .unwrap();
-    assert!(rx.try_recv().is_err());
+    assert_that!(rx.try_recv(), err(anything()));
   }
 
   #[test]
@@ -1595,11 +1596,11 @@ mod tests {
       ..Default::default()
     };
     let (inner, _rx) = build_inner(modifier, BitFlags::empty(), SeccompBpf::On);
-    assert!(inner.timestamp_now().is_some());
+    assert_that!(inner.timestamp_now(), some(anything()));
     assert!(inner.seccomp_bpf());
 
     let (inner, _rx) = build_inner(ModifierArgs::default(), BitFlags::empty(), SeccompBpf::Off);
-    assert!(inner.timestamp_now().is_none());
+    assert_that!(inner.timestamp_now(), none());
     assert!(!inner.seccomp_bpf());
   }
 }

--- a/crates/tracexec-backend-ptrace/src/ptrace/tracer/test.rs
+++ b/crates/tracexec-backend-ptrace/src/ptrace/tracer/test.rs
@@ -21,6 +21,7 @@ use rstest::{
   rstest,
 };
 use serial_test::file_serial;
+use test_that::prelude::*;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tracexec_core::{
   cli::{
@@ -136,14 +137,20 @@ fn build_ptrace_reports_missing_required_configuration() {
     .build_ptrace()
     .err()
     .expect("an incomplete builder must fail");
-  assert!(err.to_string().contains("tracer mode is required"));
+  assert_that!(
+    err.to_string(),
+    contains_substring("tracer mode is required")
+  );
 
   let err = TracerBuilder::new()
     .mode(TracerMode::Log { foreground: false })
     .build_ptrace()
     .err()
     .expect("an incomplete builder must fail");
-  assert!(err.to_string().contains("tracer event sender is required"));
+  assert_that!(
+    err.to_string(),
+    contains_substring("tracer event sender is required")
+  );
 }
 
 #[test]
@@ -154,7 +161,10 @@ fn spawn_rejects_token_from_another_tracer() {
   let err = subject
     .spawn(Vec::new(), None, other_token)
     .expect_err("a token from another tracer must fail");
-  assert!(err.to_string().contains("does not belong to this tracer"));
+  assert_that!(
+    err.to_string(),
+    contains_substring("does not belong to this tracer")
+  );
 }
 
 #[traced_test]
@@ -243,14 +253,16 @@ async fn tracer_emits_exec_event(
       assert_eq!(filename, true_executable);
       // The environment is not modified
       let env_diff = exec.env_diff.as_ref().unwrap();
-      assert!(env_diff.added.is_empty(), "added env: {:?}", env_diff.added);
-      assert!(
-        env_diff.removed.is_empty(),
+      assert_that!(env_diff.added, empty(), "added env: {:?}", env_diff.added);
+      assert_that!(
+        env_diff.removed,
+        empty(),
         "removed env: {:?}",
         env_diff.removed
       );
-      assert!(
-        env_diff.modified.is_empty(),
+      assert_that!(
+        env_diff.modified,
+        empty(),
         "modified env: {:?}",
         env_diff.modified
       );

--- a/crates/tracexec-core/Cargo.toml
+++ b/crates/tracexec-core/Cargo.toml
@@ -50,3 +50,4 @@ rand = "0.10"
 [dev-dependencies]
 serde_json = { workspace = true }
 rusty-fork = { workspace = true }
+test-that = { workspace = true }

--- a/crates/tracexec-core/src/account.rs
+++ b/crates/tracexec-core/src/account.rs
@@ -218,6 +218,8 @@ fn pathbuf_from_bytes(s: &str) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
+  use test_that::prelude::*;
+
   use super::*;
 
   #[test]
@@ -233,17 +235,15 @@ mod tests {
 
   #[test]
   fn test_parse_passwd_line_skips_malformed_lines() {
-    assert!(parse_passwd_line("# comment").unwrap().is_none());
-    assert!(parse_passwd_line("missing:fields").unwrap().is_none());
-    assert!(
-      parse_passwd_line("alice:x:not-a-uid:100:Alice:/home/alice:/bin/bash")
-        .unwrap()
-        .is_none()
+    assert_that!(parse_passwd_line("# comment").unwrap(), none());
+    assert_that!(parse_passwd_line("missing:fields").unwrap(), none());
+    assert_that!(
+      parse_passwd_line("alice:x:not-a-uid:100:Alice:/home/alice:/bin/bash").unwrap(),
+      none()
     );
-    assert!(
-      parse_passwd_line("alice:x:1000:100:Alice:/home/alice:/bin/bash:extra")
-        .unwrap()
-        .is_none()
+    assert_that!(
+      parse_passwd_line("alice:x:1000:100:Alice:/home/alice:/bin/bash:extra").unwrap(),
+      none()
     );
   }
 

--- a/crates/tracexec-core/src/breakpoint.rs
+++ b/crates/tracexec-core/src/breakpoint.rs
@@ -186,6 +186,7 @@ impl TryFrom<&str> for BreakPoint {
 #[cfg(test)]
 mod tests {
   use nix::errno::Errno;
+  use test_that::prelude::*;
 
   use super::*;
   use crate::cache::ArcStr;
@@ -217,9 +218,15 @@ mod tests {
     assert_eq!(bp3.to_editable(), "exact-filename:/bin/sh");
 
     // invalid prefix
-    assert!(BreakPointPattern::from_editable("unknown:abc").is_err());
+    assert_that!(
+      BreakPointPattern::from_editable("unknown:abc"),
+      err(anything())
+    );
     // missing colon
-    assert!(BreakPointPattern::from_editable("no-colon").is_err());
+    assert_that!(
+      BreakPointPattern::from_editable("no-colon"),
+      err(anything())
+    );
   }
 
   #[test]
@@ -283,15 +290,21 @@ mod tests {
     }
 
     // missing stop
-    assert!(BreakPoint::try_from("no-colon-here").is_err());
+    assert_that!(BreakPoint::try_from("no-colon-here"), err(anything()));
 
     // invalid stop
-    assert!(BreakPoint::try_from("badstop:argv-regex:foo").is_err());
+    assert_that!(
+      BreakPoint::try_from("badstop:argv-regex:foo"),
+      err(anything())
+    );
 
     // missing pattern kind
-    assert!(BreakPoint::try_from("sysenter:badformat").is_err());
+    assert_that!(BreakPoint::try_from("sysenter:badformat"), err(anything()));
 
     // invalid pattern kind
-    assert!(BreakPoint::try_from("sysenter:unknown-kind:xyz").is_err());
+    assert_that!(
+      BreakPoint::try_from("sysenter:unknown-kind:xyz"),
+      err(anything())
+    );
   }
 }

--- a/crates/tracexec-core/src/cli.rs
+++ b/crates/tracexec-core/src/cli.rs
@@ -358,6 +358,8 @@ mod tests {
     path::PathBuf,
   };
 
+  use test_that::prelude::*;
+
   use super::*;
   use crate::cli::{
     args::{
@@ -430,7 +432,7 @@ mod tests {
     let args = vec!["tracexec", "--elevate", "tui", "-t", "--", "sudo", "ls"];
     let cli = Cli::parse_from(args);
     assert!(cli.elevate);
-    assert!(cli.user.is_none());
+    assert_that!(cli.user, none());
     if let CliCommand::Tui { cmd, .. } = cli.cmd {
       assert_eq!(cmd, vec!["sudo", "ls"]);
     } else {
@@ -454,7 +456,7 @@ mod tests {
   fn test_cli_parse_elevate_conflicts_with_user() {
     let args = vec!["tracexec", "--elevate", "--user", "root", "log", "--", "ls"];
     let result = Cli::try_parse_from(args);
-    assert!(result.is_err());
+    assert_that!(result, err(anything()));
   }
 
   #[test]
@@ -468,7 +470,7 @@ mod tests {
       "ls",
     ];
     let result = Cli::try_parse_from(args);
-    assert!(result.is_err());
+    assert_that!(result, err(anything()));
   }
 
   #[test]
@@ -515,7 +517,7 @@ mod tests {
     drop(out);
 
     let content = fs::read_to_string(path).unwrap();
-    assert!(content.contains("Hello world"));
+    assert_that!(content, contains_substring("Hello world"));
   }
 
   #[test]

--- a/crates/tracexec-core/src/cli/args.rs
+++ b/crates/tracexec-core/src/cli/args.rs
@@ -653,6 +653,7 @@ pub struct ExporterArgs {
 #[cfg(test)]
 mod tests {
   use clap::Parser;
+  use test_that::prelude::*;
 
   use super::*;
 
@@ -805,7 +806,7 @@ mod tests {
   #[test]
   fn test_tracer_event_filter_duplicate() {
     let err = tracer_event_filter_parser("warning,warning").unwrap_err();
-    assert!(err.contains("already included"));
+    assert_that!(err, contains_substring("already included"));
   }
 
   #[test]
@@ -824,7 +825,7 @@ mod tests {
       filter_exclude: TracerEventDetailsKind::Error.into(),
     };
 
-    assert!(args.filter().is_err());
+    assert_that!(args.filter(), err(anything()));
   }
 
   /* ---------------------------- LogModeArgs ------------------------------ */
@@ -1102,13 +1103,13 @@ mod tests {
   fn test_frame_rate_parser_too_low() {
     let err = frame_rate_parser("1").unwrap_err();
     let msg = err.to_string();
-    assert!(msg.contains("too low"));
+    assert_that!(msg, contains_substring("too low"));
   }
 
   #[test]
   fn test_frame_rate_parser_invalid() {
     let err = frame_rate_parser("-1").unwrap_err();
-    assert!(err.to_string().contains("Invalid"));
+    assert_that!(err.to_string(), contains_substring("Invalid"));
   }
 
   /* ----------------------------- ExporterArgs ---------------------------- */

--- a/crates/tracexec-core/src/cli/config.rs
+++ b/crates/tracexec-core/src/cli/config.rs
@@ -253,6 +253,7 @@ pub fn project_directory() -> Option<TracexecProjectDirs> {
 mod tests {
   use std::path::PathBuf;
 
+  use test_that::prelude::*;
   use toml;
 
   use super::*;
@@ -291,13 +292,13 @@ mod tests {
   #[test]
   fn test_deserialize_frame_rate_invalid() {
     let value: Result<FrameRate, _> = toml::from_str("frame_rate = -1");
-    assert!(value.is_err());
+    assert_that!(value.err(), some(anything()));
 
     let value: Result<FrameRate, _> = toml::from_str("frame_rate = NaN");
-    assert!(value.is_err());
+    assert_that!(value.err(), some(anything()));
 
     let value: Result<FrameRate, _> = toml::from_str("frame_rate = 0");
-    assert!(value.is_err());
+    assert_that!(value.err(), some(anything()));
   }
 
   #[test]
@@ -377,7 +378,7 @@ theme = { app-title = { fg = "cyan", modifiers = ["bold"] } }
     assert_eq!(cfg.max_events.unwrap(), 100);
     assert_eq!(cfg.theme_file, Some(PathBuf::from("nord.toml")));
     let theme = cfg.theme.unwrap();
-    assert!(theme.app_title.is_some());
+    assert_that!(theme.app_title, some(anything()));
     let app_title = theme.app_title.unwrap();
     assert!(
       matches!(app_title.fg, Some(crate::cli::tui_theme::ThemeColor::Named(ref s)) if s == "cyan")

--- a/crates/tracexec-core/src/cmdbuilder.rs
+++ b/crates/tracexec-core/src/cmdbuilder.rs
@@ -303,6 +303,7 @@ mod tests {
 
   use rusty_fork::rusty_fork_test;
   use tempfile::TempDir;
+  use test_that::prelude::*;
 
   use super::*;
 
@@ -319,7 +320,7 @@ mod tests {
   fn test_new_builder() {
     let b = CommandBuilder::new("echo");
     assert_eq!(b.get_argv(), &vec![OsString::from("echo")]);
-    assert!(b.get_cwd().is_none());
+    assert_that!(b.get_cwd(), none());
     assert!(b.get_controlling_tty());
   }
 
@@ -361,7 +362,7 @@ mod tests {
     assert_eq!(b.get_cwd(), Some(tmp.path()));
 
     b.clear_cwd();
-    assert!(b.get_cwd().is_none());
+    assert_that!(b.get_cwd(), none());
   }
 
   #[test]
@@ -407,8 +408,8 @@ mod tests {
     let dir = TempDir::new().unwrap();
     let b = CommandBuilder::new("does_not_exist");
 
-    let err = b.search_path(OsStr::new("does_not_exist"), dir.path());
-    assert!(err.is_err());
+    let result = b.search_path(OsStr::new("does_not_exist"), dir.path());
+    assert_that!(result, err(anything()));
   }
 
   rusty_fork_test! {
@@ -435,7 +436,7 @@ mod tests {
       let args: Vec<&str> = cmd.args.iter().map(|c| c.to_str().unwrap()).collect();
 
       assert_eq!(args, ["echo", "hello"]);
-      assert!(cmd.env.is_none());
+      assert_that!(cmd.env, none());
       dir.close().unwrap()
     }
 

--- a/crates/tracexec-core/src/event.rs
+++ b/crates/tracexec-core/src/event.rs
@@ -386,6 +386,7 @@ mod tests {
 
   use chrono::Local;
   use nix::unistd::Pid;
+  use test_that::prelude::*;
 
   use super::*;
   use crate::{
@@ -415,7 +416,7 @@ mod tests {
   fn test_tracer_event_allocate_id_increments() {
     let id1 = TracerEvent::allocate_id();
     let id2 = TracerEvent::allocate_id();
-    assert!(id2.into_inner() > id1.into_inner());
+    assert_that!(id2.into_inner(), gt(id1.into_inner()));
   }
 
   #[test]
@@ -464,7 +465,8 @@ mod tests {
     let argv_err: Result<Vec<OutputMsg>, InspectError> = Err(InspectError::EPERM);
 
     let s = TracerEventDetails::argv_to_string(&argv_ok);
-    assert!(s.contains("arg1") && s.contains("arg2"));
+    assert_that!(s, contains_substring("arg1"));
+    assert_that!(s, contains_substring("arg2"));
 
     let s_err = TracerEventDetails::argv_to_string(&argv_err);
     assert_eq!(s_err, "[failed to read argv]");
@@ -485,7 +487,8 @@ mod tests {
     assert_eq!(s_one, "none");
 
     let s_many = TracerEventDetails::interpreters_to_string(&many);
-    assert!(s_many.contains("none") && s_many.contains(","));
+    assert_that!(s_many, contains_substring("none"));
+    assert_that!(s_many, contains_substring(","));
   }
 
   #[test]

--- a/crates/tracexec-core/src/event/id.rs
+++ b/crates/tracexec-core/src/event/id.rs
@@ -32,6 +32,8 @@ impl EventId {
 
 #[cfg(test)]
 mod tests {
+  use test_that::prelude::*;
+
   use super::EventId;
 
   #[test]
@@ -71,12 +73,13 @@ mod tests {
   fn test_equality_and_ordering() {
     let a = EventId::new(1);
     let b = EventId::new(2);
-    assert!(a < b);
-    assert!(b > a);
+    assert_that!(a, lt(b));
+    assert_that!(b, gt(a));
     assert_eq!(a, EventId::new(1));
   }
 
   #[test]
+  #[allow(clippy::clone_on_copy)]
   fn test_clone_copy() {
     let id = EventId::new(42);
     let c1 = id;

--- a/crates/tracexec-core/src/event/message.rs
+++ b/crates/tracexec-core/src/event/message.rs
@@ -245,6 +245,7 @@ mod tests {
   };
 
   use nix::errno::Errno;
+  use test_that::prelude::*;
 
   use super::*;
   use crate::cache::ArcStr;
@@ -345,8 +346,11 @@ mod tests {
     let partial = OutputMsg::PartialOk(ArcStr::from("partial"));
     let err = OutputMsg::Err(FriendlyError::InspectError(Errno::EINVAL));
 
-    assert!(format!("{}", ok).contains("ok"));
-    assert!(format!("{}", partial).contains("partial"));
-    assert!(format!("{}", err).contains("[err: failed to inspect]"));
+    assert_that!(format!("{}", ok), contains_substring("ok"));
+    assert_that!(format!("{}", partial), contains_substring("partial"));
+    assert_that!(
+      format!("{}", err),
+      contains_substring("[err: failed to inspect]")
+    );
   }
 }

--- a/crates/tracexec-core/src/event/parent.rs
+++ b/crates/tracexec-core/src/event/parent.rs
@@ -109,6 +109,8 @@ impl ParentTracker {
 
 #[cfg(test)]
 mod tests {
+  use test_that::prelude::*;
+
   use super::*;
 
   #[test]
@@ -191,7 +193,7 @@ mod tests {
 
     // First successful exec
     let parent_event1 = tracker.update_last_exec(first_exec, true);
-    assert!(parent_event1.is_none());
+    assert_that!(parent_event1, none());
     assert_eq!(tracker.last_successful_exec.unwrap().into_inner(), 1);
 
     // Second successful exec

--- a/crates/tracexec-core/src/primitives/local_chan.rs
+++ b/crates/tracexec-core/src/primitives/local_chan.rs
@@ -44,6 +44,8 @@ impl<T> LocalUnboundedReceiver<T> {
 
 #[cfg(test)]
 mod tests {
+  use test_that::prelude::*;
+
   use super::*;
 
   #[test]
@@ -53,16 +55,16 @@ mod tests {
     sender.send(42);
     sender.send(100);
 
-    assert_eq!(receiver.receive(), Some(42));
-    assert_eq!(receiver.receive(), Some(100));
+    assert_that!(receiver.receive(), some(eq(42)));
+    assert_that!(receiver.receive(), some(eq(100)));
     // Queue is now empty
-    assert_eq!(receiver.receive(), None);
+    assert_that!(receiver.receive(), none());
   }
 
   #[test]
   fn test_receive_empty_channel() {
     let (_sender, receiver): (LocalUnboundedSender<i32>, _) = unbounded();
-    assert_eq!(receiver.receive(), None);
+    assert_that!(receiver.receive(), none());
   }
 
   #[test]
@@ -75,12 +77,12 @@ mod tests {
     sender2.send(2);
 
     // Order is preserved
-    assert_eq!(receiver1.receive(), Some(1));
-    assert_eq!(receiver2.receive(), Some(2));
+    assert_that!(receiver1.receive(), some(eq(1)));
+    assert_that!(receiver2.receive(), some(eq(2)));
 
     // Channel empty now
-    assert_eq!(receiver1.receive(), None);
-    assert_eq!(receiver2.receive(), None);
+    assert_that!(receiver1.receive(), none());
+    assert_that!(receiver2.receive(), none());
   }
 
   #[test]
@@ -92,10 +94,10 @@ mod tests {
     }
 
     for i in 0..10 {
-      assert_eq!(receiver.receive(), Some(i));
+      assert_that!(receiver.receive(), some(eq(i)));
     }
 
-    assert_eq!(receiver.receive(), None);
+    assert_that!(receiver.receive(), none());
   }
 
   #[test]
@@ -107,8 +109,8 @@ mod tests {
     sender.send(1);
     sender2.send(2);
 
-    assert_eq!(receiver2.receive(), Some(1));
-    assert_eq!(receiver.receive(), Some(2));
-    assert_eq!(receiver2.receive(), None);
+    assert_that!(receiver2.receive(), some(eq(1)));
+    assert_that!(receiver.receive(), some(eq(2)));
+    assert_that!(receiver2.receive(), none());
   }
 }

--- a/crates/tracexec-core/src/printer.rs
+++ b/crates/tracexec-core/src/printer.rs
@@ -852,6 +852,7 @@ mod tests {
     fcntl::OFlag,
     unistd::Pid,
   };
+  use test_that::prelude::*;
 
   use super::*;
   use crate::{
@@ -1008,11 +1009,14 @@ mod tests {
     printer.print_fd(&mut out, &fds).unwrap();
     let rendered = String::from_utf8(out).unwrap();
     dbg!(&rendered);
-    assert!(rendered.contains("closed: stdin"));
-    assert!(rendered.contains("stdout=\"/tmp/stdout.log\""));
-    assert!(rendered.contains("cloexec: stderr"));
-    assert!(rendered.contains("3=\"/tmp/extra\""));
-    assert!(rendered.contains("cloexec: 4=\"/tmp/closed-on-exec\""));
+    assert_that!(rendered, contains_substring("closed: stdin"));
+    assert_that!(rendered, contains_substring("stdout=\"/tmp/stdout.log\""));
+    assert_that!(rendered, contains_substring("cloexec: stderr"));
+    assert_that!(rendered, contains_substring("3=\"/tmp/extra\""));
+    assert_that!(
+      rendered,
+      contains_substring("cloexec: 4=\"/tmp/closed-on-exec\"")
+    );
 
     args.trace_fd = FdPrintFormat::Raw;
     args.hide_cloexec_fds = true;
@@ -1020,14 +1024,14 @@ mod tests {
     let mut out = Vec::new();
     printer.print_fd(&mut out, &fds).unwrap();
     let rendered = String::from_utf8(out).unwrap();
-    assert!(rendered.contains("1=\"/tmp/stdout.log\""));
-    assert!(!rendered.contains("closed-on-exec"));
+    assert_that!(rendered, contains_substring("1=\"/tmp/stdout.log\""));
+    assert_that!(rendered, not(contains_substring("closed-on-exec")));
 
     args.trace_fd = FdPrintFormat::None;
     let printer = Printer::new(args, baseline);
     let mut out = Vec::new();
     printer.print_fd(&mut out, &fds).unwrap();
-    assert!(out.is_empty());
+    assert_that!(out, empty());
   }
 
   #[test]
@@ -1065,13 +1069,16 @@ mod tests {
 
     dbg!(&rendered);
 
-    assert!(rendered.contains("123<echo>: \"/bin/echo\""));
-    assert!(rendered.contains("[\"/bin/echo\", \"hello world\"]"));
-    assert!(rendered.contains("at \"/exec-cwd\""));
-    assert!(rendered.contains("interpreter"));
-    assert!(rendered.contains("+\"ADDED\"=\"value\""));
-    assert!(rendered.contains("M\"MODIFIED\"=\"new\""));
-    assert!(rendered.contains("-\"REMOVED\"=\"gone\""));
+    assert_that!(rendered, contains_substring("123<echo>: \"/bin/echo\""));
+    assert_that!(
+      rendered,
+      contains_substring("[\"/bin/echo\", \"hello world\"]")
+    );
+    assert_that!(rendered, contains_substring("at \"/exec-cwd\""));
+    assert_that!(rendered, contains_substring("interpreter"));
+    assert_that!(rendered, contains_substring("+\"ADDED\"=\"value\""));
+    assert_that!(rendered, contains_substring("M\"MODIFIED\"=\"new\""));
+    assert_that!(rendered, contains_substring("-\"REMOVED\"=\"gone\""));
   }
 
   #[test]
@@ -1100,9 +1107,9 @@ mod tests {
       )
     });
 
-    assert!(rendered.contains("Failed to read envp"));
-    assert!(rendered.contains("Failed to read argv"));
-    assert!(rendered.contains("warning"));
+    assert_that!(rendered, contains_substring("Failed to read envp"));
+    assert_that!(rendered, contains_substring("Failed to read argv"));
+    assert_that!(rendered, contains_substring("warning"));
   }
 
   #[test]
@@ -1146,17 +1153,17 @@ mod tests {
       )
     });
 
-    assert!(rendered.contains("cmdline env"));
-    assert!(rendered.contains("</tmp/stdin"));
-    assert!(rendered.contains(">/tmp/stdout"));
-    assert!(rendered.contains("2>&-"));
-    assert!(rendered.contains("5<>/tmp/fd5"));
-    assert!(rendered.contains("-a custom-argv0"));
-    assert!(rendered.contains("-C /exec-cwd"));
-    assert!(rendered.contains("-u REMOVED"));
-    assert!(rendered.contains("ADDED=value"));
-    assert!(rendered.contains("MODIFIED=$'new value'"));
-    assert!(rendered.contains("/bin/echo $'hello world'"));
+    assert_that!(rendered, contains_substring("cmdline env"));
+    assert_that!(rendered, contains_substring("</tmp/stdin"));
+    assert_that!(rendered, contains_substring(">/tmp/stdout"));
+    assert_that!(rendered, contains_substring("2>&-"));
+    assert_that!(rendered, contains_substring("5<>/tmp/fd5"));
+    assert_that!(rendered, contains_substring("-a custom-argv0"));
+    assert_that!(rendered, contains_substring("-C /exec-cwd"));
+    assert_that!(rendered, contains_substring("-u REMOVED"));
+    assert_that!(rendered, contains_substring("ADDED=value"));
+    assert_that!(rendered, contains_substring("MODIFIED=$'new value'"));
+    assert_that!(rendered, contains_substring("/bin/echo $'hello world'"));
   }
 
   #[test]

--- a/crates/tracexec-core/src/proc.rs
+++ b/crates/tracexec-core/src/proc.rs
@@ -944,6 +944,7 @@ static CACHE: StringCache = StringCache;
 
 #[cfg(test)]
 mod proc_status_tests {
+
   use super::*;
 
   #[test]
@@ -1015,6 +1016,7 @@ Groups:\t0
 
 #[cfg(test)]
 mod env_tests {
+
   use super::*;
   use crate::event::FriendlyError;
 
@@ -1132,6 +1134,7 @@ mod env_diff_tests {
 
 #[cfg(test)]
 mod fdinfo_tests {
+
   use crate::proc::FileDescriptorInfo;
 
   #[test]
@@ -1182,6 +1185,7 @@ mod interpreter_test {
   };
 
   use tempfile::tempdir;
+  use test_that::prelude::*;
 
   use crate::proc::{
     Interpreter,
@@ -1193,10 +1197,10 @@ mod interpreter_test {
   #[test]
   fn test_interpreter_display() {
     let none = Interpreter::None;
-    assert!(none.to_string().contains("none"));
+    assert_that!(none.to_string(), contains_substring("none"));
 
     let err = Interpreter::Error(cached_str("boom"));
-    assert!(err.to_string().contains("err"));
+    assert_that!(err.to_string(), contains_substring("err"));
   }
 
   #[test]
@@ -1224,7 +1228,7 @@ mod interpreter_test {
 
     let result = read_interpreter(&script);
     match result {
-      Interpreter::Shebang(s) => assert!(s.as_ref().ends_with("target")),
+      Interpreter::Shebang(s) => assert_that!(s.as_ref(), ends_with("target")),
       other => panic!("unexpected result: {other:?}"),
     }
     dir.close().unwrap();
@@ -1299,14 +1303,14 @@ mod interpreter_test {
 
     match &result[0] {
       Interpreter::Shebang(s) => {
-        assert!(s.as_ref().ends_with("interp1"));
+        assert_that!(s.as_ref(), ends_with("interp1"));
       }
       other => panic!("unexpected interpreter: {other:?}"),
     }
 
     match &result[1] {
       Interpreter::Shebang(s) => {
-        assert!(s.as_ref().ends_with("interp2"));
+        assert_that!(s.as_ref(), ends_with("interp2"));
       }
       other => panic!("unexpected interpreter: {other:?}"),
     }
@@ -1325,7 +1329,7 @@ mod interpreter_test {
     File::create(&exe).unwrap();
 
     let result = read_interpreter_recursive(&exe);
-    assert!(result.is_empty());
+    assert_that!(result, empty());
     dir.close().unwrap();
   }
 }

--- a/crates/tracexec-core/src/pty.rs
+++ b/crates/tracexec-core/src/pty.rs
@@ -33,6 +33,7 @@ use std::{
     CString,
     OsStr,
   },
+  fmt::Debug,
   fs::File,
   io,
   io::{
@@ -781,6 +782,7 @@ mod tests {
   };
 
   use nix::sys::wait::waitpid;
+  use test_that::prelude::*;
 
   use super::*;
 
@@ -834,8 +836,11 @@ mod tests {
     let mut buf = [0u8; 64];
     let n = reader.read(&mut buf).unwrap();
 
-    assert!(n > 0);
-    assert!(std::str::from_utf8(&buf[..n]).unwrap().contains("hello"));
+    assert_that!(n, gt(0));
+    assert_that!(
+      std::str::from_utf8(&buf[..n]).unwrap(),
+      contains_substring("hello")
+    );
   }
 
   #[test]
@@ -887,7 +892,7 @@ mod tests {
     let ok = ExitStatus::with_exit_code(0);
     assert!(ok.success());
     assert_eq!(ok.exit_code(), 0);
-    assert!(ok.signal().is_none());
+    assert_that!(ok.signal(), none());
 
     let sig = ExitStatus::with_signal("SIGTERM");
     assert!(!sig.success());

--- a/crates/tracexec-core/src/timestamp.rs
+++ b/crates/tracexec-core/src/timestamp.rs
@@ -52,6 +52,7 @@ mod tests {
     DateTime,
     Local,
   };
+  use test_that::prelude::*;
 
   use super::*;
 
@@ -60,19 +61,16 @@ mod tests {
   #[test]
   fn timestamp_format_accepts_valid_strftime() {
     let fmt = TimestampFormat::from_str("%Y-%m-%d %H:%M:%S");
-    assert!(fmt.is_ok());
+    assert_that!(fmt, ok(anything()));
   }
 
   #[test]
   fn timestamp_format_rejects_newline() {
     let fmt = TimestampFormat::from_str("%Y-%m-%d\n%H:%M:%S");
-    assert!(fmt.is_err());
+    assert_that!(fmt, err(anything()));
 
     let err = fmt.unwrap_err();
-    assert!(
-      err.contains("should not contain newline"),
-      "unexpected error message: {err}"
-    );
+    assert_that!(err, contains_substring("should not contain newline"));
   }
 
   #[test]
@@ -85,18 +83,14 @@ mod tests {
 
   #[test]
   fn boot_time_is_non_zero() {
-    assert!(*BOOT_TIME > 0);
+    assert_that!(*BOOT_TIME, gt(0));
   }
 
   #[test]
   fn boot_time_is_reasonable_unix_time() {
     // boot time should be after year 2000
     const YEAR_2000_NS: u64 = 946684800_u64 * 1_000_000_000;
-    assert!(
-      *BOOT_TIME > YEAR_2000_NS,
-      "BOOT_TIME too small: {}",
-      *BOOT_TIME
-    );
+    assert_that!(*BOOT_TIME, gt(YEAR_2000_NS));
   }
 
   /* ---------------- ts_from_boot_ns ---------------- */
@@ -114,7 +108,7 @@ mod tests {
     let t1 = ts_from_boot_ns(1_000);
     let t2 = ts_from_boot_ns(2_000);
 
-    assert!(t2 > t1);
+    assert_that!(t2, gt(t1));
   }
 
   #[test]

--- a/crates/tracexec-core/src/tracer.rs
+++ b/crates/tracexec-core/src/tracer.rs
@@ -325,6 +325,7 @@ mod tests {
 
   use chrono::Local;
   use nix::sys::signal::Signal as NixSignal;
+  use test_that::prelude::*;
 
   use super::*;
   use crate::event::OutputMsg;
@@ -453,13 +454,13 @@ mod tests {
     assert_eq!(exec.exec_pid, Pid::from_raw(1234));
     assert_eq!(exec.filename, filename);
     assert_eq!(exec.cwd, cwd);
-    assert!(exec.argv.is_ok());
-    assert!(exec.envp.is_ok());
+    assert_that!(exec.argv, points_to(ok(anything())));
+    assert_that!(exec.envp, points_to(ok(anything())));
     assert!(!exec.has_dash_env);
-    assert!(exec.interpreters.is_none());
-    assert!(Arc::strong_count(&exec.argv) >= 1);
-    assert!(Arc::strong_count(&exec.envp) >= 1);
-    assert!(Arc::strong_count(&exec.fdinfo) >= 1);
+    assert_that!(exec.interpreters, none());
+    assert_that!(Arc::strong_count(&exec.argv), ge(1));
+    assert_that!(Arc::strong_count(&exec.envp), ge(1));
+    assert_that!(Arc::strong_count(&exec.fdinfo), ge(1));
   }
 
   /* ---------------- ProcessExit ---------------- */

--- a/crates/tracexec-exporter-json/Cargo.toml
+++ b/crates/tracexec-exporter-json/Cargo.toml
@@ -21,3 +21,6 @@ color-eyre = { workspace = true }
 nix = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }
+
+[dev-dependencies]
+test-that = { workspace = true }

--- a/crates/tracexec-exporter-json/src/lib.rs
+++ b/crates/tracexec-exporter-json/src/lib.rs
@@ -1,4 +1,5 @@
 //! Data structures for export command
+
 use std::{
   error::Error,
   io,
@@ -309,6 +310,7 @@ mod tests {
     errno::Errno,
     unistd::Pid,
   };
+  use test_that::prelude::*;
   use tokio::sync::mpsc::unbounded_channel;
   use tracexec_core::{
     cli::args::ExporterArgs,
@@ -482,7 +484,7 @@ mod tests {
       .into_iter::<serde_json::Value>()
       .collect::<Result<_, _>>()
       .unwrap();
-    assert!(values.len() >= 2);
+    assert_that!(values.len(), ge(2));
     assert!(values[0].get("generator").is_some());
     assert!(values[1].get("id").is_some());
     assert_eq!(values[1]["cgroup"]["kind"], "v2");

--- a/crates/tracexec-exporter-perfetto/Cargo.toml
+++ b/crates/tracexec-exporter-perfetto/Cargo.toml
@@ -35,3 +35,6 @@ prost = { workspace = true }
 bytes = { workspace = true }
 tokio = { workspace = true }
 nix = { workspace = true }
+
+[dev-dependencies]
+test-that = { workspace = true }

--- a/crates/tracexec-exporter-perfetto/src/packet.rs
+++ b/crates/tracexec-exporter-perfetto/src/packet.rs
@@ -469,6 +469,7 @@ mod tests {
     errno::Errno,
     unistd::Pid,
   };
+  use test_that::prelude::*;
   use tracexec_core::{
     event::{
       ExecEvent,
@@ -575,7 +576,7 @@ mod tests {
       panic!("expected interned string value for cgroup annotation");
     };
 
-    assert_eq!(
+    assert_that!(
       packet.interned_data.as_ref().and_then(|data| {
         data
           .debug_annotation_string_values
@@ -584,9 +585,9 @@ mod tests {
           .and_then(|s| s.str.as_deref())
           .and_then(|s| String::from_utf8(s.to_vec()).ok())
       }),
-      Some(format_cgroup_annotation(&CgroupInfo::V2 {
+      some(eq(format_cgroup_annotation(&CgroupInfo::V2 {
         path: "/user.slice/test.scope".to_string(),
-      }))
+      }))),
     );
   }
 }

--- a/crates/tracexec-exporter-perfetto/src/perfetto.rs
+++ b/crates/tracexec-exporter-perfetto/src/perfetto.rs
@@ -86,6 +86,7 @@ mod tests {
     errno::Errno,
     unistd::Pid,
   };
+  use test_that::prelude::*;
   use tokio::sync::mpsc::unbounded_channel;
   use tracexec_core::{
     cli::args::ExporterArgs,
@@ -179,6 +180,6 @@ mod tests {
     drop(tx);
     let code = exporter.run().await.unwrap();
     assert_eq!(code, 7);
-    assert!(!output.lock().unwrap().is_empty());
+    assert_that!(output.lock().unwrap().len(), gt(0));
   }
 }

--- a/crates/tracexec-exporter-perfetto/src/producer.rs
+++ b/crates/tracexec-exporter-perfetto/src/producer.rs
@@ -520,6 +520,7 @@ mod tests {
     errno::Errno,
     unistd::Pid,
   };
+  use test_that::prelude::*;
   use tracexec_core::{
     event::{
       EventId,
@@ -643,6 +644,6 @@ mod tests {
         details: TracerEventDetails::Exec(Box::new(child)),
       }))
       .unwrap();
-    assert!(!packets.is_empty());
+    assert_that!(packets, not(empty()));
   }
 }

--- a/crates/tracexec-exporter-perfetto/src/recorder.rs
+++ b/crates/tracexec-exporter-perfetto/src/recorder.rs
@@ -58,6 +58,8 @@ impl<W: std::io::Write> Drop for PerfettoTraceRecorder<W> {
 
 #[cfg(test)]
 mod tests {
+  use test_that::prelude::*;
+
   use super::PerfettoTraceRecorder;
   use crate::proto::TracePacket;
 
@@ -66,9 +68,9 @@ mod tests {
     let mut recorder = PerfettoTraceRecorder::new(Vec::new());
     recorder.record(TracePacket::default()).unwrap();
     recorder.record(TracePacket::default()).unwrap();
-    assert!(!recorder.buf.is_empty());
+    assert_that!(recorder.buf, not(empty()));
     recorder.flush().unwrap();
-    assert!(recorder.buf.is_empty());
-    assert!(!recorder.writer.is_empty());
+    assert_that!(recorder.buf, empty());
+    assert_that!(recorder.writer, not(empty()));
   }
 }

--- a/crates/tracexec-tui/Cargo.toml
+++ b/crates/tracexec-tui/Cargo.toml
@@ -58,4 +58,5 @@ indexset = "0.15"
 insta = "1.41.0"
 serial_test = { workspace = true }
 tempfile = { workspace = true }
+test-that = { workspace = true }
 tracing-test = { workspace = true }

--- a/crates/tracexec-tui/src/app.rs
+++ b/crates/tracexec-tui/src/app.rs
@@ -806,6 +806,7 @@ mod tests {
     backend::TestBackend,
     text::Line,
   };
+  use test_that::prelude::*;
   use tracexec_core::{
     cli::{
       args::{
@@ -874,12 +875,12 @@ mod tests {
     app.activate_experiment("test-experiment");
     assert_eq!(app.active_experiments, vec!["test-experiment"]);
 
-    assert!(app.signal_root_process(Signal::SIGTERM).is_ok());
-    assert!(app.exit().is_ok());
+    assert_that!(app.signal_root_process(Signal::SIGTERM), ok(anything()));
+    assert_that!(app.exit(), ok(anything()));
 
-    assert_eq!(app.active_event_list().is_following(), false);
+    assert!(!(app.active_event_list().is_following()));
     app.inspect_all_event_list_mut(|list| list.toggle_follow());
-    assert_eq!(app.event_list.is_following(), true);
+    assert!(app.event_list.is_following());
 
     Ok(())
   }
@@ -1085,14 +1086,14 @@ mod tests {
     app.event_list.push(EventId::new(0), event.clone());
 
     let narrow = render_app_to_string(&mut app, 3, 12);
-    assert!(narrow.contains("too"));
+    assert_that!(narrow, contains_substring("too"));
     app.should_handle_internal_resize = true;
     let short = render_app_to_string(&mut app, 80, 5);
-    assert!(short.contains("too small"));
+    assert_that!(short, contains_substring("too small"));
 
     app.popup.push(ActivePopup::Help);
     let help = render_app_to_string(&mut app, 100, 28);
-    assert!(help.contains("Help"));
+    assert_that!(help, contains_substring("Help"));
     app.popup.pop();
 
     app.popup.push(ActivePopup::InfoPopup(InfoPopupState::info(
@@ -1101,7 +1102,7 @@ mod tests {
       app.theme,
     )));
     let info = render_app_to_string(&mut app, 100, 28);
-    assert!(info.contains("render info popup"));
+    assert_that!(info, contains_substring("render info popup"));
     app.popup.pop();
 
     app
@@ -1112,7 +1113,13 @@ mod tests {
         app.theme,
       )));
     let copy = render_app_to_string(&mut app, 100, 28);
-    assert!(copy.contains("Commandline") || copy.contains("Line"));
+    assert_that!(
+      copy,
+      any!(
+        contains_substring("Commandline"),
+        contains_substring("Line")
+      )
+    );
     app.popup.pop();
 
     let selected = app.event_list.get_for_test(EventId::new(0)).unwrap();
@@ -1123,14 +1130,17 @@ mod tests {
         &app.event_list,
       )));
     let details = render_app_to_string(&mut app, 100, 28);
-    assert!(details.contains("render target"));
+    assert_that!(details, contains_substring("render target"));
     app.popup.pop();
 
     let mut query_builder = QueryBuilder::new(QueryKind::Search);
     query_builder.edit();
     app.query_builder = Some(query_builder);
     let search = render_app_to_string(&mut app, 100, 28);
-    assert!(search.contains("Execute") || search.contains("Search"));
+    assert_that!(
+      search,
+      any!(contains_substring("Execute"), contains_substring("Search"))
+    );
 
     Ok(())
   }
@@ -1167,16 +1177,16 @@ mod tests {
     assert_eq!(app.split_percentage, 50);
 
     let rendered = render_app_to_string(&mut app, 100, 32);
-    assert!(rendered.contains("Terminal"));
-    assert!(rendered.contains("Events"));
+    assert_that!(rendered, contains_substring("Terminal"));
+    assert_that!(rendered, contains_substring("Events"));
     assert!(!app.should_handle_internal_resize);
 
     app.active_pane = ActivePane::Events;
     app.layout = AppLayout::Horizontal;
     app.should_handle_internal_resize = true;
     let rendered = render_app_to_string(&mut app, 100, 32);
-    assert!(rendered.contains("Layout"));
-    assert!(rendered.contains("Grow/Shrink"));
+    assert_that!(rendered, contains_substring("Layout"));
+    assert_that!(rendered, contains_substring("Grow/Shrink"));
 
     Ok(())
   }

--- a/crates/tracexec-tui/src/breakpoint_manager.rs
+++ b/crates/tracexec-tui/src/breakpoint_manager.rs
@@ -236,6 +236,7 @@ mod tests {
     Terminal,
     backend::TestBackend,
   };
+  use test_that::prelude::*;
   use tracexec_backend_ptrace::ptrace::RunningTracer;
   use tracexec_core::{
     breakpoint::{
@@ -436,7 +437,7 @@ mod tests {
   fn test_breakpoint_manager_help() {
     let help = super::BreakPointManager::help(keys().as_ref(), current_theme());
     assert_eq!(help.title, "How to use Breakpoints");
-    assert!(!help.message.is_empty());
+    assert_that!(help.message, not(empty()));
     // Check that the help contains expected content
     let content = help
       .message
@@ -444,11 +445,11 @@ mod tests {
       .map(|line: &ratatui::text::Line| line.to_string())
       .collect::<Vec<_>>()
       .join("\n");
-    assert!(content.contains("syscall-enter"));
-    assert!(content.contains("syscall-exit"));
-    assert!(content.contains("in-filename"));
-    assert!(content.contains("exact-filename"));
-    assert!(content.contains("argv-regex"));
+    assert_that!(content, contains_substring("syscall-enter"));
+    assert_that!(content, contains_substring("syscall-exit"));
+    assert_that!(content, contains_substring("in-filename"));
+    assert_that!(content, contains_substring("exact-filename"));
+    assert_that!(content, contains_substring("argv-regex"));
   }
 
   #[test]
@@ -481,7 +482,7 @@ mod tests {
       KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE),
       keys().as_ref(),
     );
-    assert!(state.editor.is_none());
+    assert_that!(state.editor, none());
     assert_eq!(state.breakpoints.len(), 1);
     let (id, breakpoint) = state.breakpoints.iter().next().unwrap();
     let breakpoint = breakpoint.clone();

--- a/crates/tracexec-tui/src/details_popup.rs
+++ b/crates/tracexec-tui/src/details_popup.rs
@@ -895,6 +895,7 @@ mod tests {
     fcntl::OFlag,
     unistd::Pid,
   };
+  use test_that::prelude::*;
   use tracexec_core::{
     cache::ArcStr,
     cli::{
@@ -1149,9 +1150,9 @@ mod tests {
       test_area_full(100, 20),
       &mut state,
     );
-    assert!(env_rendered.contains("ADD"));
-    assert!(env_rendered.contains("OLD"));
-    assert!(env_rendered.contains("MOD"));
+    assert_that!(env_rendered, contains_substring("ADD"));
+    assert_that!(env_rendered, contains_substring("OLD"));
+    assert_that!(env_rendered, contains_substring("MOD"));
 
     state.next_tab();
     assert_eq!(state.active_tab(), "FdInfo");
@@ -1160,8 +1161,8 @@ mod tests {
       test_area_full(100, 24),
       &mut state,
     );
-    assert!(fd_rendered.contains("/tmp/stdin"));
-    assert!(fd_rendered.contains("eventfd-count"));
+    assert_that!(fd_rendered, contains_substring("/tmp/stdin"));
+    assert_that!(fd_rendered, contains_substring("eventfd-count"));
 
     state.prev_tab();
     state.circle_tab();

--- a/crates/tracexec-tui/src/event.rs
+++ b/crates/tracexec-tui/src/event.rs
@@ -357,6 +357,7 @@ mod tests {
     fcntl::OFlag,
     unistd::Pid,
   };
+  use test_that::prelude::*;
   use tracexec_core::{
     cache::ArcStr,
     event::{
@@ -522,12 +523,15 @@ mod tests {
       .collect::<Vec<_>>()
       .join("\n");
 
-    assert!(rendered.contains("[info]: info"));
-    assert!(rendered.contains("[warn]: warn"));
-    assert!(rendered.contains("error: err"));
-    assert!(rendered.contains("new child 11"));
-    assert!(rendered.contains("tracee spawned: 20"));
-    assert!(rendered.contains("tracee exit: signal: None, exit_code: 7"));
+    assert_that!(rendered, contains_substring("[info]: info"));
+    assert_that!(rendered, contains_substring("[warn]: warn"));
+    assert_that!(rendered, contains_substring("error: err"));
+    assert_that!(rendered, contains_substring("new child 11"));
+    assert_that!(rendered, contains_substring("tracee spawned: 20"));
+    assert_that!(
+      rendered,
+      contains_substring("tracee exit: signal: None, exit_code: 7")
+    );
   }
 
   #[test]
@@ -574,17 +578,17 @@ mod tests {
         theme,
       )
       .to_string();
-    assert!(commandline.contains("env -a custom-argv0"));
-    assert!(commandline.contains("-C /work"));
-    assert!(commandline.contains("-u REMOVED"));
-    assert!(commandline.contains("--"));
-    assert!(commandline.contains("-ADDED=dash"));
-    assert!(commandline.contains("MODIFIED=$'new value'"));
-    assert!(commandline.contains("/bin/echo $'hello world'"));
-    assert!(commandline.contains("</tmp/stdin"));
-    assert!(commandline.contains(">/tmp/stdout"));
-    assert!(commandline.contains("2>&-"));
-    assert!(commandline.contains("5<>/tmp/fd5"));
+    assert_that!(commandline, contains_substring("env -a custom-argv0"));
+    assert_that!(commandline, contains_substring("-C /work"));
+    assert_that!(commandline, contains_substring("-u REMOVED"));
+    assert_that!(commandline, contains_substring("--"));
+    assert_that!(commandline, contains_substring("-ADDED=dash"));
+    assert_that!(commandline, contains_substring("MODIFIED=$'new value'"));
+    assert_that!(commandline, contains_substring("/bin/echo $'hello world'"));
+    assert_that!(commandline, contains_substring("</tmp/stdin"));
+    assert_that!(commandline, contains_substring(">/tmp/stdout"));
+    assert_that!(commandline, contains_substring("2>&-"));
+    assert_that!(commandline, contains_substring("5<>/tmp/fd5"));
 
     let full_env = event
       .to_event_line(
@@ -599,8 +603,8 @@ mod tests {
         theme,
       )
       .to_string();
-    assert!(full_env.contains("-i --"));
-    assert!(full_env.contains("KEEP=same"));
+    assert_that!(full_env, contains_substring("-i --"));
+    assert_that!(full_env, contains_substring("KEEP=same"));
   }
 
   #[test]
@@ -609,75 +613,68 @@ mod tests {
     let event = exec_details();
     let modifier = ModifierArgs::default();
 
-    assert!(
-      event
-        .text_for_copy(
-          &baseline,
-          CopyTarget::Line,
-          &modifier,
-          RuntimeModifier::default()
-        )
-        .contains("/bin/echo")
+    assert_that!(
+      event.text_for_copy(
+        &baseline,
+        CopyTarget::Line,
+        &modifier,
+        RuntimeModifier::default()
+      ),
+      contains_substring("/bin/echo")
     );
-    assert!(
-      event
-        .text_for_copy(
-          &baseline,
-          CopyTarget::Commandline(SupportedShell::Bash),
-          &modifier,
-          RuntimeModifier::default()
-        )
-        .contains("custom-argv0")
+    assert_that!(
+      event.text_for_copy(
+        &baseline,
+        CopyTarget::Commandline(SupportedShell::Bash),
+        &modifier,
+        RuntimeModifier::default()
+      ),
+      contains_substring("custom-argv0")
     );
-    assert!(
-      event
-        .text_for_copy(
-          &baseline,
-          CopyTarget::CommandlineWithFullEnv(SupportedShell::Sh),
-          &modifier,
-          RuntimeModifier::default()
-        )
-        .contains("-i --")
+    assert_that!(
+      event.text_for_copy(
+        &baseline,
+        CopyTarget::CommandlineWithFullEnv(SupportedShell::Sh),
+        &modifier,
+        RuntimeModifier::default()
+      ),
+      contains_substring("-i --")
     );
-    assert!(
-      event
-        .text_for_copy(
-          &baseline,
-          CopyTarget::CommandlineWithStdio(SupportedShell::Fish),
-          &modifier,
-          RuntimeModifier::default()
-        )
-        .contains("</tmp/stdin")
+    assert_that!(
+      event.text_for_copy(
+        &baseline,
+        CopyTarget::CommandlineWithStdio(SupportedShell::Fish),
+        &modifier,
+        RuntimeModifier::default()
+      ),
+      contains_substring("</tmp/stdin")
     );
-    assert!(
-      event
-        .text_for_copy(
-          &baseline,
-          CopyTarget::CommandlineWithFds(SupportedShell::Bash),
-          &modifier,
-          RuntimeModifier::default()
-        )
-        .contains("5<>/tmp/fd5")
+    assert_that!(
+      event.text_for_copy(
+        &baseline,
+        CopyTarget::CommandlineWithFds(SupportedShell::Bash),
+        &modifier,
+        RuntimeModifier::default()
+      ),
+      contains_substring("5<>/tmp/fd5")
     );
-    assert!(
-      event
-        .text_for_copy(
-          &baseline,
-          CopyTarget::Env,
-          &modifier,
-          RuntimeModifier::default()
-        )
-        .contains("\"KEEP\"=\"same\"")
+    assert_that!(
+      event.text_for_copy(
+        &baseline,
+        CopyTarget::Env,
+        &modifier,
+        RuntimeModifier::default()
+      ),
+      contains_substring("\"KEEP\"=\"same\"")
     );
-    assert!(
-      event
-        .text_for_copy(
-          &baseline,
-          CopyTarget::EnvDiff,
-          &modifier,
-          RuntimeModifier::default()
-        )
-        .contains("# Added:")
+    assert_that!(
+      event.text_for_copy(
+        &baseline,
+        CopyTarget::EnvDiff,
+        &modifier,
+        RuntimeModifier::default()
+      ),
+      contains_substring("# Added:")
     );
     assert!(
       event
@@ -725,15 +722,14 @@ mod tests {
     failing.envp = Arc::new(Err(Errno::EPERM));
     failing.env_diff = Err(Errno::EPERM);
     let failing = TracerEventDetails::Exec(Box::new(failing));
-    assert!(
-      failing
-        .text_for_copy(
-          &baseline,
-          CopyTarget::Argv,
-          &modifier,
-          RuntimeModifier::default()
-        )
-        .contains("failed to read argv")
+    assert_that!(
+      failing.text_for_copy(
+        &baseline,
+        CopyTarget::Argv,
+        &modifier,
+        RuntimeModifier::default()
+      ),
+      contains_substring("failed to read argv")
     );
     assert_eq!(
       failing.text_for_copy(
@@ -744,15 +740,14 @@ mod tests {
       ),
       "[failed to read argv]"
     );
-    assert!(
-      failing
-        .text_for_copy(
-          &baseline,
-          CopyTarget::Env,
-          &modifier,
-          RuntimeModifier::default()
-        )
-        .contains("failed to read envp")
+    assert_that!(
+      failing.text_for_copy(
+        &baseline,
+        CopyTarget::Env,
+        &modifier,
+        RuntimeModifier::default()
+      ),
+      contains_substring("failed to read envp")
     );
     assert_eq!(
       failing.text_for_copy(

--- a/crates/tracexec-tui/src/hit_manager.rs
+++ b/crates/tracexec-tui/src/hit_manager.rs
@@ -494,6 +494,7 @@ mod tests {
     layout::Rect,
   };
   use serial_test::file_serial;
+  use test_that::prelude::*;
   use tracexec_backend_ptrace::ptrace::{
     RunningTracer,
     clear_breakpoint_id_counter,
@@ -772,7 +773,7 @@ mod tests {
       keys().as_ref(),
     );
     assert!(matches!(action, Some(Action::HideHitManager)));
-    assert!(state.hits.is_empty());
+    assert_that!(state.hits, empty());
     assert_eq!(state.list_state.selected, None);
   }
 
@@ -790,7 +791,7 @@ mod tests {
       keys().as_ref(),
     );
     assert!(matches!(action, Some(Action::HideHitManager)));
-    assert!(state.hits.is_empty());
+    assert_that!(state.hits, empty());
   }
 
   #[test]
@@ -813,7 +814,7 @@ mod tests {
       keys().as_ref(),
     );
     assert!(matches!(action, Some(Action::HideHitManager)));
-    assert!(state.hits.is_empty());
+    assert_that!(state.hits, empty());
     assert!(state.pending_detach_reactions.contains_key(&hid));
   }
 
@@ -840,7 +841,7 @@ mod tests {
       keys().as_ref(),
     );
     assert!(matches!(action, Some(Action::HideHitManager)));
-    assert!(state.hits.is_empty());
+    assert_that!(state.hits, empty());
     assert!(state.pending_detach_reactions.contains_key(&hid));
   }
 }

--- a/crates/tracexec-tui/src/query.rs
+++ b/crates/tracexec-tui/src/query.rs
@@ -324,6 +324,7 @@ mod tests {
     backend::TestBackend,
     text::Line,
   };
+  use test_that::prelude::*;
   use tracexec_core::{
     cli::keys::TuiKeyBindings,
     event::EventId,
@@ -431,8 +432,8 @@ mod tests {
 
     let line = qr.statistics(current_theme());
     let s = line.to_string();
-    assert!(s.contains("2")); // selected index
-    assert!(s.contains("3")); // total matches
+    assert_that!(s, contains_substring("2")); // selected index
+    assert_that!(s, contains_substring("3")); // total matches
   }
 
   #[test]

--- a/crates/tracexec-tui/src/theme.rs
+++ b/crates/tracexec-tui/src/theme.rs
@@ -578,6 +578,7 @@ mod tests {
     Color,
     Modifier,
   };
+  use test_that::prelude::*;
 
   use super::*;
 
@@ -722,10 +723,9 @@ mod tests {
     )
     .unwrap_err();
 
-    assert!(
-      err
-        .to_string()
-        .contains("cannot specify both 'theme-file' and 'theme'")
+    assert_that!(
+      err.to_string(),
+      contains_substring("cannot specify both 'theme-file' and 'theme'")
     );
   }
 

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -6,6 +6,13 @@ use assert_cmd::{
 };
 use predicates::prelude::*;
 use serial_test::file_serial;
+use test_that::{
+  assert_that,
+  matchers::{
+    contains_substring,
+    gt,
+  },
+};
 
 #[test]
 #[file_serial]
@@ -162,12 +169,14 @@ fn restore_env_socket_passes_full_env_to_tracee() -> Result<(), Box<dyn std::err
   server.join().expect("env server panicked")?;
   let stdout = String::from_utf8_lossy(&output.stdout);
 
-  assert!(
-    stdout.contains("MARKER=preserved_value"),
+  assert_that!(
+    stdout,
+    contains_substring("MARKER=preserved_value"),
     "Custom env var should be preserved, got stdout: {stdout}"
   );
-  assert!(
-    stdout.contains("SUDO=from_socket\n"),
+  assert_that!(
+    stdout,
+    contains_substring("SUDO=from_socket\n"),
     "SUDO_USER should come from the transferred original env, got stdout: {stdout}"
   );
   Ok(())
@@ -272,7 +281,7 @@ fn ebpf_collect_perfetto_runs_tracee() -> Result<(), Box<dyn std::error::Error>>
     .arg("-c")
     .arg("true");
   cmd.assert().success();
-  assert!(std::fs::metadata(&output)?.len() > 0);
+  assert_that!(std::fs::metadata(&output)?.len(), gt(0));
   Ok(())
 }
 


### PR DESCRIPTION
See https://hovinen.me/announcements/2026/06/24/introducing-test-that.html for the rationale.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized test assertions across backend, core, exporter, TUI, and smoke suites using a matcher-based style (`test-that`).
  * Improved readability and failure diagnostics for errors, substrings, collections/optionals, and numeric thresholds.
  * Kept all test intent the same while making expectations more expressive (e.g., empty/non-empty, `some/none`, and range checks).
* **Chores**
  * Added `test-that` as a workspace-managed development dependency and enabled it for relevant crates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->