### PR TITLE
chore: update UKCI kernels

### DIFF
--- a/nix/ukci.nix
+++ b/nix/ukci.nix
@@ -162,16 +162,6 @@ localFlake:
                 extraMakeFlags = [ ];
               }
 
-              {
-                name = "7.2";
-                tag = "v7.2-rc7";
-                version = "7.2.0-rc7";
-                source = "torvalds";
-                test_exe = "tracexec";
-                sha256 = "sha256-qiF4Zu6madqNhCEhYRMacxW7lNr81zmp6eKU1l50jBA=";
-                kernelPatches = [ ];
-                extraMakeFlags = [ ];
-              }
             ])
             ++ (lib.optionals (!isTargetRiscv64) [
               # {


### PR DESCRIPTION
Automated UKCI kernel update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed support for building and testing Linux kernel v7.2-rc7 in UKCI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->