### PR TITLE
fix: fake version for snapshot testing

### DIFF
--- a/crates/tracexec-tui/src/app.rs
+++ b/crates/tracexec-tui/src/app.rs
@@ -853,19 +853,6 @@ mod tests {
     Event::Key(KeyEvent::new(binding.code, binding.modifiers))
   }
 
-  /// Fake version substituted into rendered output so snapshots stay stable
-  /// across version bumps.
-  const FAKE_VERSION: &str = "0.0.0-fake";
-
-  /// Replace the real crate version in the rendered output with a fake one to
-  /// keep snapshot tests consistent regardless of the current crate version.
-  fn with_fake_version(rendered: String) -> String {
-    rendered.replace(
-      &format!(" tracexec {}", env!("CARGO_PKG_VERSION")),
-      &format!(" tracexec {}", FAKE_VERSION),
-    )
-  }
-
   #[test]
   fn app_no_pty_shrink_grow_noop_and_inspect_event_list() -> color_eyre::Result<()> {
     let baseline = std::sync::Arc::new(BaselineInfo::new()?);
@@ -1285,7 +1272,7 @@ mod tests {
         app.render(f.area(), f.buffer_mut());
       })
       .unwrap();
-    let rendered = with_fake_version(format!("{:?}", terminal.backend().buffer()));
+    let rendered = format!("{:?}", terminal.backend().buffer());
     assert_snapshot!(rendered);
   }
 
@@ -1327,7 +1314,7 @@ mod tests {
         app.render(f.area(), f.buffer_mut());
       })
       .unwrap();
-    let rendered = with_fake_version(format!("{:?}", terminal.backend().buffer()));
+    let rendered = format!("{:?}", terminal.backend().buffer());
     assert_snapshot!(rendered);
   }
 }

--- a/crates/tracexec-tui/src/app/ui.rs
+++ b/crates/tracexec-tui/src/app/ui.rs
@@ -48,6 +48,11 @@ use crate::{
   backtrace_popup::BacktracePopup,
 };
 
+#[cfg(test)]
+const TRACEXEC_VERSION: &str = "0.0.0-fake";
+#[cfg(not(test))]
+const TRACEXEC_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 impl Widget for &mut App {
   fn render(self, area: Rect, buf: &mut Buffer) {
     // Create a space for header, todo list and the footer.
@@ -68,7 +73,7 @@ impl Widget for &mut App {
       Layout::vertical
     })(horizontal_constraints)
     .areas(rest_area);
-    let mut title = vec![Span::from(" tracexec "), env!("CARGO_PKG_VERSION").into()];
+    let mut title = vec![Span::from(" tracexec "), TRACEXEC_VERSION.into()];
     if !self.active_experiments.is_empty() {
       title.push(Span::from(" with "));
       title.push(Span::from("experimental ").yellow());

--- a/crates/tracexec-tui/src/snapshots/tracexec_tui__app__tests__snapshot_app_render.snap
+++ b/crates/tracexec-tui/src/snapshots/tracexec_tui__app__tests__snapshot_app_render.snap
@@ -5,7 +5,7 @@ expression: rendered
 Buffer {
     area: Rect { x: 0, y: 0, width: 80, height: 24 },
     content: [
-        " tracexec 0.0.0-fake                                                                ",
+        " tracexec 0.0.0-fake                                                            ",
         "                                                                                ",
         "┌Events───────────────────────────────────────────────────────────────────1/1──┐",
         "│  123[info]: Test event                                                       │",

--- a/crates/tracexec-tui/src/snapshots/tracexec_tui__app__tests__snapshot_app_render_with_custom_theme.snap
+++ b/crates/tracexec-tui/src/snapshots/tracexec_tui__app__tests__snapshot_app_render_with_custom_theme.snap
@@ -5,7 +5,7 @@ expression: rendered
 Buffer {
     area: Rect { x: 0, y: 0, width: 80, height: 24 },
     content: [
-        " tracexec 0.0.0-fake                                                                ",
+        " tracexec 0.0.0-fake                                                            ",
         "                                                                                ",
         "┌Events───────────────────────────────────────────────────────────────────1/1──┐",
         "│  123[info]: Themed event                                                     │",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated terminal rendering snapshots to use the actual displayed application version.
  * Improved test consistency by sharing the version value used in title rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->